### PR TITLE
refactor(ad-unit): emit lifecycle events and add managed container div

### DIFF
--- a/src/ad-unit.test.ts
+++ b/src/ad-unit.test.ts
@@ -38,6 +38,23 @@ describe("AdUnit", () => {
       container.appendChild(element);
       expect(element.shadowRoot?.innerHTML).toContain("<slot>");
     });
+
+    test("shadow DOM contains a managed container div", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      container.appendChild(element);
+      const div = element.shadowRoot?.querySelector('div[part="container"]');
+      expect(div).not.toBeNull();
+      expect(div).toBeInstanceOf(HTMLDivElement);
+    });
+
+    test("exposes container div via element.container", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      container.appendChild(element);
+      expect(element.container).toBeInstanceOf(HTMLDivElement);
+      expect(element.container).toBe(
+        element.shadowRoot?.querySelector('div[part="container"]'),
+      );
+    });
   });
 
   describe("code property", () => {
@@ -262,6 +279,162 @@ describe("AdUnit", () => {
 
       // biome-ignore lint/suspicious/noExplicitAny: verifying vendor decoupling
       expect((window as any).pbjs).toBeUndefined();
+    });
+  });
+
+  describe("lifecycle events", () => {
+    test("fires ad-unit:connected synchronously on connect", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("code", "test-ad");
+      element.setAttribute("sizes", "300x250");
+
+      let received: CustomEvent | null = null;
+      element.addEventListener("ad-unit:connected", (e) => {
+        received = e as CustomEvent;
+      });
+
+      container.appendChild(element);
+
+      expect(received).not.toBeNull();
+      expect((received as unknown as CustomEvent).type).toBe(
+        "ad-unit:connected",
+      );
+    });
+
+    test("fires ad-unit:disconnected when element leaves DOM", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("code", "test-ad");
+      container.appendChild(element);
+
+      let received: CustomEvent | null = null;
+      element.addEventListener("ad-unit:disconnected", (e) => {
+        received = e as CustomEvent;
+      });
+
+      container.removeChild(element);
+
+      expect(received).not.toBeNull();
+      expect((received as unknown as CustomEvent).type).toBe(
+        "ad-unit:disconnected",
+      );
+    });
+
+    test("ad-unit:connected is bubbles, composed, cancelable", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      let received: CustomEvent | null = null;
+      element.addEventListener("ad-unit:connected", (e) => {
+        received = e as CustomEvent;
+      });
+
+      container.appendChild(element);
+
+      const e = received as unknown as CustomEvent;
+      expect(e.bubbles).toBe(true);
+      expect(e.composed).toBe(true);
+      expect(e.cancelable).toBe(true);
+    });
+
+    test("ad-unit:disconnected is bubbles, composed, cancelable", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      container.appendChild(element);
+
+      let received: CustomEvent | null = null;
+      element.addEventListener("ad-unit:disconnected", (e) => {
+        received = e as CustomEvent;
+      });
+
+      container.removeChild(element);
+
+      const e = received as unknown as CustomEvent;
+      expect(e.bubbles).toBe(true);
+      expect(e.composed).toBe(true);
+      expect(e.cancelable).toBe(true);
+    });
+
+    test("document-level listener receives ad-unit:connected (bubbles + composed)", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("code", "header-ad");
+      element.setAttribute("sizes", "728x90");
+
+      let received: CustomEvent | null = null;
+      const handler = (e: Event) => {
+        received = e as CustomEvent;
+      };
+      document.addEventListener("ad-unit:connected", handler);
+
+      try {
+        container.appendChild(element);
+      } finally {
+        document.removeEventListener("ad-unit:connected", handler);
+      }
+
+      expect(received).not.toBeNull();
+      const e = received as unknown as CustomEvent;
+      expect(e.type).toBe("ad-unit:connected");
+      expect(e.detail.code).toBe("header-ad");
+      expect(e.detail.container).toBe(element.container);
+    });
+
+    test("ad-unit:disconnected detail carries full configuration", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("code", "test-ad");
+      element.setAttribute("sizes", "300x250");
+      element.setAttribute("gpid", "/1234/test");
+      container.appendChild(element);
+
+      let detail: Record<string, unknown> | null = null;
+      element.addEventListener("ad-unit:disconnected", (e) => {
+        detail = (e as CustomEvent).detail;
+      });
+
+      container.removeChild(element);
+
+      expect(detail).not.toBeNull();
+      const d = detail as unknown as {
+        code: string;
+        sizes: number[][];
+        gpid: string | null;
+        container: HTMLElement;
+      };
+      expect(d.code).toBe("test-ad");
+      expect(d.sizes).toEqual([[300, 250]]);
+      expect(d.gpid).toBe("/1234/test");
+      expect(d.container).toBe(element.container);
+    });
+
+    test("ad-unit:connected detail carries full configuration", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("code", "header-ad");
+      element.setAttribute("sizes", "728x90,970x250");
+      element.setAttribute("gpid", "/1234/homepage/header");
+      element.setAttribute("pos", "1");
+      element.setAttribute("format", '[{"w":728,"h":90}]');
+
+      let detail: Record<string, unknown> | null = null;
+      element.addEventListener("ad-unit:connected", (e) => {
+        detail = (e as CustomEvent).detail;
+      });
+
+      container.appendChild(element);
+
+      expect(detail).not.toBeNull();
+      const d = detail as unknown as {
+        code: string;
+        sizes: number[][];
+        gpid: string | null;
+        pos: number | null;
+        format: unknown;
+        container: HTMLElement;
+      };
+      expect(d.code).toBe("header-ad");
+      expect(d.sizes).toEqual([
+        [728, 90],
+        [970, 250],
+      ]);
+      expect(d.gpid).toBe("/1234/homepage/header");
+      expect(d.pos).toBe(1);
+      expect(d.format).toEqual([{ w: 728, h: 90 }]);
+      expect(d.container).toBe(element.container);
     });
   });
 

--- a/src/ad-unit.ts
+++ b/src/ad-unit.ts
@@ -31,9 +31,24 @@ export class AdUnit extends HTMLElement {
     "name",
   ];
 
+  #container: HTMLDivElement;
+
   constructor() {
     super();
-    this.attachShadow({ mode: "open" });
+    const root = this.attachShadow({ mode: "open" });
+    const style = document.createElement("style");
+    style.textContent = ":host { display: block; }";
+    this.#container = document.createElement("div");
+    this.#container.setAttribute("part", "container");
+    this.#container.appendChild(document.createElement("slot"));
+    root.append(style, this.#container);
+  }
+
+  /**
+   * Managed container div inside the shadow DOM. Adapters render ads here.
+   */
+  get container(): HTMLDivElement {
+    return this.#container;
   }
 
   // --- Attribute/Property reflection ---
@@ -160,11 +175,29 @@ export class AdUnit extends HTMLElement {
 
   connectedCallback() {
     this.render();
+    this.#dispatchLifecycle("ad-unit:connected");
   }
 
   disconnectedCallback() {
-    // Extension point: adapters may override or observe this lifecycle hook
-    // to clean up subscriptions when the element is removed from the DOM.
+    this.#dispatchLifecycle("ad-unit:disconnected");
+  }
+
+  #dispatchLifecycle(type: string) {
+    this.dispatchEvent(
+      new CustomEvent(type, {
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+        detail: {
+          code: this.code,
+          sizes: this.sizes,
+          gpid: this.gpid,
+          pos: this.pos,
+          format: this.format,
+          container: this.container,
+        },
+      }),
+    );
   }
 
   attributeChangedCallback(
@@ -182,16 +215,8 @@ export class AdUnit extends HTMLElement {
   // --- Rendering ---
 
   render() {
-    if (!this.shadowRoot) return;
-
-    this.shadowRoot.innerHTML = `
-      <style>
-        :host {
-          display: block;
-        }
-      </style>
-      <slot></slot>
-    `;
+    // Shadow DOM structure is stable (built in constructor). Extension point
+    // for subclasses / future behavior that reacts to attribute changes.
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #3. Rewrites `<ad-unit>` as a pure lifecycle web component (PRD Phase 1). The element now
dispatches synchronous `CustomEvent`s at each lifecycle stage so adapters can subscribe via
document-level event delegation, and exposes a managed container div inside its open shadow DOM
where ad servers will render creatives.

- Adds stable `#container` div (`part="container"`) inside shadow DOM, exposed via
  `element.container` getter
- Dispatches `ad-unit:connected` in `connectedCallback` and `ad-unit:disconnected` in
  `disconnectedCallback`
- Events are `CustomEvent` with `bubbles: true`, `composed: true`, `cancelable: true`
- `event.detail` carries `{ code, sizes, gpid, pos, format, container }` — the full slot config plus
  the container reference adapters pass to ad servers
- Shadow DOM is built once in the constructor; `render()` becomes a no-op extension point so the
  container reference stays stable across attribute changes

## Acceptance criteria

- [x] `ad-unit:connected` fires synchronously when element enters DOM
- [x] `ad-unit:disconnected` fires when element leaves DOM
- [x] Event `detail` contains `code`, `sizes`, `gpid`, `pos`, `format`, and container element
  reference
- [x] Events have `bubbles: true`, `composed: true`, `cancelable: true`
- [x] Document-level `addEventListener("ad-unit:connected", …)` receives the event (proves bubbling
+ composed works through shadow DOM)
- [x] Shadow DOM (open mode) renders with a container div inside
- [x] Attribute reflection works for all observed attributes with correct types
- [x] All new behavior covered by tests

## Test plan

- [x] `bun test` — 66/66 pass (9 new TDD tests for container div, connected/disconnected events,
  event flags, detail shape, and document-level bubbling)
- [x] `bun run lint` — clean
- [x] `bun run build` — success
- [ ] Manual: open `demo/index.html`, confirm `<ad-unit>` elements still render with slotted
  fallback text
- [ ] Manual: attach `document.addEventListener("ad-unit:connected", console.log)` and verify events
  bubble from inserted elements with full `detail` payload