### PR TITLE
Add lazy loading support for ad-unit with IntersectionObserver

### DIFF
--- a/demo/stub.css
+++ b/demo/stub.css
@@ -1,53 +1,53 @@
 * {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 body {
-    font-family: system-ui, -apple-system, sans-serif;
-    max-width: 720px;
-    margin: 0 auto;
-    padding: 4rem 2rem;
-    background: #f8fafc;
-    color: #0f172a;
-    line-height: 1.6;
+  font-family: system-ui, -apple-system, sans-serif;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+  background: #f8fafc;
+  color: #0f172a;
+  line-height: 1.6;
 }
 
 .stub__eyebrow {
-    color: #64748b;
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    margin: 0 0 0.25rem;
+  color: #64748b;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0 0 0.25rem;
 }
 
 h1 {
-    margin: 0 0 1.5rem;
-    font-size: 1.75rem;
+  margin: 0 0 1.5rem;
+  font-size: 1.75rem;
 }
 
 code {
-    background: #e2e8f0;
-    padding: 0.1rem 0.35rem;
-    border-radius: 3px;
-    font-size: 0.9em;
+  background: #e2e8f0;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.9em;
 }
 
 a {
-    color: #2563eb;
+  color: #2563eb;
 }
 
 a:hover {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .stub__back {
-    display: inline-block;
-    margin-top: 2rem;
-    color: #64748b;
-    text-decoration: none;
-    font-size: 0.875rem;
+  display: inline-block;
+  margin-top: 2rem;
+  color: #64748b;
+  text-decoration: none;
+  font-size: 0.875rem;
 }
 
 .stub__back:hover {
-    color: #0f172a;
+  color: #0f172a;
 }

--- a/docs/superpowers/specs/2026-04-14-viewport-detection-design.md
+++ b/docs/superpowers/specs/2026-04-14-viewport-detection-design.md
@@ -65,7 +65,9 @@ Both events use the same flags and detail shape as existing lifecycle events:
 
 ### Event order (lazy mode)
 
-`ad-unit:connected` fires synchronously. `ad-unit:fetch` and `ad-unit:render` fire independently when their respective observers trigger. Fetch will typically fire before render because its margin is larger, but this is not guaranteed by the implementation.
+`ad-unit:connected` fires synchronously. `ad-unit:fetch` and `ad-unit:render` fire asynchronously when their respective observers trigger.
+
+**Critical invariant: fetch always fires before render.** If the element is already in view when connected (both observers trigger immediately), the render observer callback must check `#fetchFired` before dispatching. If fetch hasn't fired yet, the render callback dispatches `ad-unit:fetch` first, then `ad-unit:render`. This guarantees adapters always see fetch before render regardless of observer callback ordering.
 
 ## Observer Lifecycle
 
@@ -88,7 +90,7 @@ Both events use the same flags and detail shape as existing lifecycle events:
 1. Reset guards: `#fetchFired = false`, `#renderFired = false`
 2. Validate margins: if fetch margin < render margin (same unit), `console.warn` with context and clamp fetch = render. Mixed units skip the check.
 3. Create fetch observer with `rootMargin: this.fetchMargin`. On intersection: if `!#fetchFired`, dispatch `ad-unit:fetch`, set `#fetchFired = true`, unobserve `this`.
-4. Create render observer with `rootMargin: this.renderMargin`. Same pattern for `ad-unit:render`.
+4. Create render observer with `rootMargin: this.renderMargin`. On intersection: if `!#renderFired`, check `#fetchFired` — if fetch hasn't fired yet, dispatch `ad-unit:fetch` first (and set `#fetchFired = true`, unobserve from fetch observer). Then dispatch `ad-unit:render`, set `#renderFired = true`, unobserve `this`.
 5. Both call `observe(this)`.
 6. Observer construction is wrapped in try/catch. On error, wrap the message with `[ad-unit "${this.code}"] Invalid fetch-margin "${value}": ${originalMessage}` (or `render-margin`) and re-throw.
 
@@ -170,6 +172,7 @@ Replaced in `beforeEach`, restored in `afterEach`.
 9. Each event fires at most once per connected lifecycle
 10. Observers disconnected on element removal
 11. Reconnect resets lifecycle (events can fire again)
+12. Element already in view on connect (lazy): fetch fires before render, both fire
 
 **Validation:**
 12. Invalid margin throws with helpful `[ad-unit "code"]` context

--- a/docs/superpowers/specs/2026-04-14-viewport-detection-design.md
+++ b/docs/superpowers/specs/2026-04-14-viewport-detection-design.md
@@ -1,0 +1,197 @@
+# Viewport Detection for Fetch/Render Zones
+
+> Design spec for [issue #4](https://github.com/evans-sam/ad-unit-component/issues/4)
+
+## Summary
+
+Add IntersectionObserver-based viewport detection to `<ad-unit>`. When lazy loading is enabled, the component uses two IntersectionObservers to detect when the element enters configurable fetch and render zones, firing `ad-unit:fetch` and `ad-unit:render` events. When lazy loading is off (the default), both events fire synchronously on connect.
+
+## Attributes
+
+### `loading`
+
+Controls whether viewport detection is observer-based or immediate.
+
+| Value | Behavior |
+|-------|----------|
+| `"eager"` (default) | `ad-unit:fetch` and `ad-unit:render` fire synchronously in `connectedCallback` |
+| `"lazy"` | Two IntersectionObservers detect viewport proximity; events fire once each when zones are entered |
+
+Absence of the attribute is equivalent to `"eager"`. The value is read once in `connectedCallback`; changing it while connected has no effect until the next disconnect/reconnect cycle. Same applies to `fetch-margin` and `render-margin`.
+
+### `fetch-margin`
+
+CSS rootMargin string for the fetch zone observer. Accepts `px` or `%` values. Only used when `loading="lazy"`.
+
+Default: `"200%"` (two full viewport heights).
+
+### `render-margin`
+
+CSS rootMargin string for the render zone observer. Accepts `px` or `%` values. Only used when `loading="lazy"`.
+
+Default: `"150%"` (1.5 viewport heights).
+
+### Constants
+
+```ts
+const DEFAULT_FETCH_MARGIN = "200%";
+const DEFAULT_RENDER_MARGIN = "150%";
+```
+
+All three attributes are added to `observedAttributes`.
+
+## Events
+
+### `ad-unit:fetch`
+
+Fired when the element enters the fetch zone. In eager mode, fires synchronously in `connectedCallback` after `ad-unit:connected`. In lazy mode, fires when the fetch observer's callback triggers.
+
+### `ad-unit:render`
+
+Fired when the element enters the render zone. Same dispatch rules as `ad-unit:fetch` but for the render zone.
+
+### Event configuration
+
+Both events use the same flags and detail shape as existing lifecycle events:
+
+- `bubbles: true`
+- `composed: true`
+- `cancelable: true`
+- `detail: { code, sizes, gpid, pos, format, container }`
+
+### Event order (eager mode)
+
+`ad-unit:connected` -> `ad-unit:fetch` -> `ad-unit:render` (all synchronous in `connectedCallback`).
+
+### Event order (lazy mode)
+
+`ad-unit:connected` fires synchronously. `ad-unit:fetch` and `ad-unit:render` fire independently when their respective observers trigger. Fetch will typically fire before render because its margin is larger, but this is not guaranteed by the implementation.
+
+## Observer Lifecycle
+
+### Private fields
+
+```ts
+#fetchObserver: IntersectionObserver | null = null;
+#renderObserver: IntersectionObserver | null = null;
+#fetchFired = false;
+#renderFired = false;
+```
+
+### `connectedCallback` (after existing `render()` + `ad-unit:connected`)
+
+**Eager path** (`loading` is absent or `"eager"`):
+1. Dispatch `ad-unit:fetch`
+2. Dispatch `ad-unit:render`
+
+**Lazy path** (`loading="lazy"`):
+1. Reset guards: `#fetchFired = false`, `#renderFired = false`
+2. Validate margins: if fetch margin < render margin (same unit), `console.warn` with context and clamp fetch = render. Mixed units skip the check.
+3. Create fetch observer with `rootMargin: this.fetchMargin`. On intersection: if `!#fetchFired`, dispatch `ad-unit:fetch`, set `#fetchFired = true`, unobserve `this`.
+4. Create render observer with `rootMargin: this.renderMargin`. Same pattern for `ad-unit:render`.
+5. Both call `observe(this)`.
+6. Observer construction is wrapped in try/catch. On error, wrap the message with `[ad-unit "${this.code}"] Invalid fetch-margin "${value}": ${originalMessage}` (or `render-margin`) and re-throw.
+
+### `disconnectedCallback` (before existing `ad-unit:disconnected`)
+
+1. Call `disconnect()` on both observers.
+2. Null both fields.
+
+Observers are kept alive after both events fire (not eagerly cleaned up). They will be reused for future viewability tracking.
+
+### Reconnect behavior
+
+When an element is removed and re-appended to the DOM, `connectedCallback` runs again: guards reset, new observers are created, events can fire again. This behavior may be revisited as real adapter patterns emerge.
+
+## Margin Validation
+
+### Fetch < render (same unit)
+
+If `fetch-margin` resolves to a smaller value than `render-margin` and both use the same unit, this is a misconfiguration. The component will:
+1. `console.warn` with context: `[ad-unit "${this.code}"] fetch-margin (${fetchMargin}) is less than render-margin (${renderMargin}), clamping fetch-margin to render-margin`
+2. Clamp fetch margin to equal render margin for observer creation.
+
+If the two margins use different units (e.g., one `px` and one `%`), the check is skipped.
+
+### Invalid rootMargin
+
+If the `IntersectionObserver` constructor throws due to an invalid margin value, the error is caught, wrapped with element context, and re-thrown:
+
+```
+[ad-unit "header-ad"] Invalid fetch-margin "banana": Failed to construct 'IntersectionObserver': ...
+```
+
+The original stack trace is preserved.
+
+## Property Reflection
+
+New getters/setters following the existing pattern:
+
+```ts
+get loading(): string {
+  return this.getAttribute("loading") ?? "eager";
+}
+
+get fetchMargin(): string {
+  return this.getAttribute("fetch-margin") ?? DEFAULT_FETCH_MARGIN;
+}
+
+get renderMargin(): string {
+  return this.getAttribute("render-margin") ?? DEFAULT_RENDER_MARGIN;
+}
+```
+
+Each has a corresponding setter that calls `setAttribute`.
+
+## Testing Strategy
+
+### IntersectionObserver mock
+
+happy-dom's `IntersectionObserver` is a stub (no-op observe/disconnect). Tests replace `globalThis.IntersectionObserver` with a manual mock that:
+- Captures `(callback, options)` on construction
+- Tracks observed targets and `unobserve`/`disconnect` calls
+- Exposes a `trigger(target, isIntersecting)` helper to invoke the callback with a minimal entry-shaped object
+
+Replaced in `beforeEach`, restored in `afterEach`.
+
+### Test cases
+
+**Eager mode (default):**
+1. `ad-unit:fetch` fires synchronously on connect when no `loading` attribute
+2. `ad-unit:render` fires synchronously on connect when no `loading` attribute
+3. Event order: `connected` before `fetch` before `render`
+4. No `IntersectionObserver` created in eager mode
+
+**Lazy mode:**
+5. `ad-unit:fetch` fires when fetch observer triggers intersection
+6. `ad-unit:render` fires when render observer triggers intersection
+7. Default margins are `200%` (fetch) and `150%` (render)
+8. Custom margins via `fetch-margin` / `render-margin` attributes
+9. Each event fires at most once per connected lifecycle
+10. Observers disconnected on element removal
+11. Reconnect resets lifecycle (events can fire again)
+
+**Validation:**
+12. Invalid margin throws with helpful `[ad-unit "code"]` context
+13. Fetch margin < render margin (same unit) warns and clamps
+
+**Event shape:**
+14. Detail carries `{ code, sizes, gpid, pos, format, container }`
+15. Events are `bubbles: true, composed: true, cancelable: true`
+
+## Out of Scope
+
+- **Chrome silent observer disconnection on CSS load**: The reference implementation (ad-project-v2 ViewabilityService) polled every 5s to detect elements silently dropped from observers. Custom element `disconnectedCallback` may handle this natively. Will validate in browser testing and address in a follow-up if needed.
+- **`preventDefault()` / `proceed()` blocking** (issue #5): Events are `cancelable` to support this, but blocking behavior is not implemented here.
+- **Viewability tracking**: Observers are kept alive after events fire to support future viewability features.
+- **Visibility change pausing**: Modern browsers pause IntersectionObserver on hidden tabs. No manual pause/resume needed.
+
+## Files Modified
+
+- `src/ad-unit.ts` — add attributes, observer lifecycle, event dispatch
+- `src/ad-unit.test.ts` — add test cases with IO mock
+
+## Reference
+
+- Previous implementation: `ad-project-v2/src/ViewabilityService/index.ts` (centralized service with observer pooling, percentage-based margins, 5s validation polling)
+- Production margins in reference: `fetchMarginPercent: 200`, `renderMarginPercent: 150`

--- a/src/ad-unit.test.ts
+++ b/src/ad-unit.test.ts
@@ -1,16 +1,72 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { AdUnit } from "./ad-unit";
 
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+  callback: IntersectionObserverCallback;
+  options: IntersectionObserverInit;
+  observed: Set<Element> = new Set();
+  disconnected = false;
+
+  constructor(
+    callback: IntersectionObserverCallback,
+    options: IntersectionObserverInit = {},
+  ) {
+    this.callback = callback;
+    this.options = options;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(target: Element) {
+    this.observed.add(target);
+  }
+
+  unobserve(target: Element) {
+    this.observed.delete(target);
+  }
+
+  disconnect() {
+    this.observed.clear();
+    this.disconnected = true;
+  }
+
+  takeRecords() {
+    return [];
+  }
+
+  trigger(target: Element, isIntersecting: boolean) {
+    this.callback(
+      [
+        {
+          target,
+          isIntersecting,
+          intersectionRatio: isIntersecting ? 1 : 0,
+          boundingClientRect: {} as DOMRectReadOnly,
+          intersectionRect: {} as DOMRectReadOnly,
+          rootBounds: null,
+          time: performance.now(),
+        },
+      ],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
 describe("AdUnit", () => {
   let container: HTMLDivElement;
+  const OriginalIntersectionObserver = globalThis.IntersectionObserver;
 
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
+    globalThis.IntersectionObserver =
+      MockIntersectionObserver as unknown as typeof IntersectionObserver;
+    MockIntersectionObserver.instances = [];
   });
 
   afterEach(() => {
     container.remove();
+    globalThis.IntersectionObserver = OriginalIntersectionObserver;
   });
 
   describe("registration", () => {
@@ -471,6 +527,424 @@ describe("AdUnit", () => {
       const renderSpy = spyOn(element, "render");
       element.setAttribute("code", "new-code");
       expect(renderSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("loading property", () => {
+    test("defaults to eager", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      expect(element.loading).toBe("eager");
+    });
+
+    test("reflects loading attribute", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      expect(element.loading).toBe("lazy");
+    });
+
+    test("sets loading attribute", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.loading = "lazy";
+      expect(element.getAttribute("loading")).toBe("lazy");
+    });
+  });
+
+  describe("fetchMargin property", () => {
+    test("defaults to 200%", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      expect(element.fetchMargin).toBe("200%");
+    });
+
+    test("reflects fetch-margin attribute", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("fetch-margin", "500px");
+      expect(element.fetchMargin).toBe("500px");
+    });
+
+    test("sets fetch-margin attribute", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.fetchMargin = "300px";
+      expect(element.getAttribute("fetch-margin")).toBe("300px");
+    });
+  });
+
+  describe("renderMargin property", () => {
+    test("defaults to 150%", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      expect(element.renderMargin).toBe("150%");
+    });
+
+    test("reflects render-margin attribute", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("render-margin", "100px");
+      expect(element.renderMargin).toBe("100px");
+    });
+
+    test("sets render-margin attribute", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.renderMargin = "50%";
+      expect(element.getAttribute("render-margin")).toBe("50%");
+    });
+  });
+
+  describe("eager mode (default)", () => {
+    test("fires ad-unit:fetch synchronously on connect", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("code", "test-ad");
+
+      let received: CustomEvent | null = null;
+      element.addEventListener("ad-unit:fetch", (e) => {
+        received = e as CustomEvent;
+      });
+
+      container.appendChild(element);
+
+      expect(received).not.toBeNull();
+      expect((received as unknown as CustomEvent).type).toBe("ad-unit:fetch");
+    });
+
+    test("fires ad-unit:render synchronously on connect", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("code", "test-ad");
+
+      let received: CustomEvent | null = null;
+      element.addEventListener("ad-unit:render", (e) => {
+        received = e as CustomEvent;
+      });
+
+      container.appendChild(element);
+
+      expect(received).not.toBeNull();
+      expect((received as unknown as CustomEvent).type).toBe("ad-unit:render");
+    });
+
+    test("event order: connected, fetch, render", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      const order: string[] = [];
+
+      element.addEventListener("ad-unit:connected", () =>
+        order.push("connected"),
+      );
+      element.addEventListener("ad-unit:fetch", () => order.push("fetch"));
+      element.addEventListener("ad-unit:render", () => order.push("render"));
+
+      container.appendChild(element);
+
+      expect(order).toEqual(["connected", "fetch", "render"]);
+    });
+
+    test("does not create IntersectionObservers", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      container.appendChild(element);
+
+      expect(MockIntersectionObserver.instances).toHaveLength(0);
+    });
+
+    test("fetch event detail carries full configuration", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("code", "header-ad");
+      element.setAttribute("sizes", "728x90");
+      element.setAttribute("gpid", "/1234/test");
+      element.setAttribute("pos", "1");
+
+      let detail: Record<string, unknown> | null = null;
+      element.addEventListener("ad-unit:fetch", (e) => {
+        detail = (e as CustomEvent).detail;
+      });
+
+      container.appendChild(element);
+
+      expect(detail).not.toBeNull();
+      const d = detail as unknown as {
+        code: string;
+        sizes: number[][];
+        gpid: string | null;
+        pos: number | null;
+        format: unknown;
+        container: HTMLElement;
+      };
+      expect(d.code).toBe("header-ad");
+      expect(d.sizes).toEqual([[728, 90]]);
+      expect(d.gpid).toBe("/1234/test");
+      expect(d.pos).toBe(1);
+      expect(d.container).toBe(element.container);
+    });
+
+    test("fetch and render events are bubbles, composed, cancelable", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      const events: CustomEvent[] = [];
+      element.addEventListener("ad-unit:fetch", (e) =>
+        events.push(e as CustomEvent),
+      );
+      element.addEventListener("ad-unit:render", (e) =>
+        events.push(e as CustomEvent),
+      );
+
+      container.appendChild(element);
+
+      expect(events).toHaveLength(2);
+      for (const e of events) {
+        expect(e.bubbles).toBe(true);
+        expect(e.composed).toBe(true);
+        expect(e.cancelable).toBe(true);
+      }
+    });
+  });
+
+  describe("lazy mode", () => {
+    test("creates two IntersectionObservers on connect", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      container.appendChild(element);
+
+      expect(MockIntersectionObserver.instances).toHaveLength(2);
+    });
+
+    test("does not fire fetch or render synchronously on connect", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      const events: string[] = [];
+      element.addEventListener("ad-unit:fetch", () => events.push("fetch"));
+      element.addEventListener("ad-unit:render", () => events.push("render"));
+
+      container.appendChild(element);
+
+      expect(events).toEqual([]);
+    });
+
+    test("fires ad-unit:fetch when fetch observer triggers", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      element.setAttribute("code", "test-ad");
+
+      let received: CustomEvent | null = null;
+      element.addEventListener("ad-unit:fetch", (e) => {
+        received = e as CustomEvent;
+      });
+
+      container.appendChild(element);
+      const fetchObserver = MockIntersectionObserver.instances[0];
+      fetchObserver.trigger(element, true);
+
+      expect(received).not.toBeNull();
+      expect((received as unknown as CustomEvent).detail.code).toBe("test-ad");
+    });
+
+    test("fires ad-unit:render when render observer triggers", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      element.setAttribute("code", "test-ad");
+
+      let received: CustomEvent | null = null;
+      element.addEventListener("ad-unit:render", (e) => {
+        received = e as CustomEvent;
+      });
+
+      container.appendChild(element);
+      const renderObserver = MockIntersectionObserver.instances[1];
+      renderObserver.trigger(element, true);
+
+      expect(received).not.toBeNull();
+      expect((received as unknown as CustomEvent).detail.code).toBe("test-ad");
+    });
+
+    test("uses default margins (200% fetch, 150% render)", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      container.appendChild(element);
+
+      const [fetchObs, renderObs] = MockIntersectionObserver.instances;
+      expect(fetchObs.options.rootMargin).toBe("200%");
+      expect(renderObs.options.rootMargin).toBe("150%");
+    });
+
+    test("uses custom margins from attributes", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      element.setAttribute("fetch-margin", "500px");
+      element.setAttribute("render-margin", "100px");
+      container.appendChild(element);
+
+      const [fetchObs, renderObs] = MockIntersectionObserver.instances;
+      expect(fetchObs.options.rootMargin).toBe("500px");
+      expect(renderObs.options.rootMargin).toBe("100px");
+    });
+
+    test("each event fires at most once", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      let fetchCount = 0;
+      let renderCount = 0;
+      element.addEventListener("ad-unit:fetch", () => fetchCount++);
+      element.addEventListener("ad-unit:render", () => renderCount++);
+
+      container.appendChild(element);
+      const [fetchObs, renderObs] = MockIntersectionObserver.instances;
+
+      fetchObs.trigger(element, true);
+      fetchObs.trigger(element, true);
+      renderObs.trigger(element, true);
+      renderObs.trigger(element, true);
+
+      expect(fetchCount).toBe(1);
+      expect(renderCount).toBe(1);
+    });
+
+    test("unobserves after event fires", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      container.appendChild(element);
+
+      const [fetchObs, renderObs] = MockIntersectionObserver.instances;
+      expect(fetchObs.observed.has(element)).toBe(true);
+
+      fetchObs.trigger(element, true);
+      expect(fetchObs.observed.has(element)).toBe(false);
+
+      renderObs.trigger(element, true);
+      expect(renderObs.observed.has(element)).toBe(false);
+    });
+
+    test("observers disconnected on element removal", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      container.appendChild(element);
+
+      const [fetchObs, renderObs] = MockIntersectionObserver.instances;
+      container.removeChild(element);
+
+      expect(fetchObs.disconnected).toBe(true);
+      expect(renderObs.disconnected).toBe(true);
+    });
+
+    test("reconnect resets lifecycle — events fire again", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      let fetchCount = 0;
+      let renderCount = 0;
+      element.addEventListener("ad-unit:fetch", () => fetchCount++);
+      element.addEventListener("ad-unit:render", () => renderCount++);
+
+      container.appendChild(element);
+      MockIntersectionObserver.instances[0].trigger(element, true);
+      MockIntersectionObserver.instances[1].trigger(element, true);
+      expect(fetchCount).toBe(1);
+      expect(renderCount).toBe(1);
+
+      container.removeChild(element);
+      container.appendChild(element);
+
+      const newFetchObs = MockIntersectionObserver.instances[2];
+      const newRenderObs = MockIntersectionObserver.instances[3];
+      newFetchObs.trigger(element, true);
+      newRenderObs.trigger(element, true);
+
+      expect(fetchCount).toBe(2);
+      expect(renderCount).toBe(2);
+    });
+
+    test("element already in view: fetch fires before render", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      const order: string[] = [];
+      element.addEventListener("ad-unit:fetch", () => order.push("fetch"));
+      element.addEventListener("ad-unit:render", () => order.push("render"));
+
+      container.appendChild(element);
+      const renderObserver = MockIntersectionObserver.instances[1];
+      renderObserver.trigger(element, true);
+
+      expect(order).toEqual(["fetch", "render"]);
+    });
+
+    test("non-intersecting entries are ignored", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      let fetchCount = 0;
+      element.addEventListener("ad-unit:fetch", () => fetchCount++);
+
+      container.appendChild(element);
+      MockIntersectionObserver.instances[0].trigger(element, false);
+
+      expect(fetchCount).toBe(0);
+    });
+  });
+
+  describe("margin validation", () => {
+    test("warns and clamps when fetch margin < render margin (same unit)", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      element.setAttribute("code", "test-ad");
+      element.setAttribute("fetch-margin", "50%");
+      element.setAttribute("render-margin", "100%");
+
+      const warnSpy = spyOn(console, "warn");
+      container.appendChild(element);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const [fetchObs, renderObs] = MockIntersectionObserver.instances;
+      expect(fetchObs.options.rootMargin).toBe("100%");
+      expect(renderObs.options.rootMargin).toBe("100%");
+      warnSpy.mockRestore();
+    });
+
+    test("warns and clamps with px units", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      element.setAttribute("fetch-margin", "50px");
+      element.setAttribute("render-margin", "200px");
+
+      const warnSpy = spyOn(console, "warn");
+      container.appendChild(element);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const [fetchObs] = MockIntersectionObserver.instances;
+      expect(fetchObs.options.rootMargin).toBe("200px");
+      warnSpy.mockRestore();
+    });
+
+    test("skips validation when units differ", () => {
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      element.setAttribute("fetch-margin", "50px");
+      element.setAttribute("render-margin", "100%");
+
+      const warnSpy = spyOn(console, "warn");
+      container.appendChild(element);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      const [fetchObs, renderObs] = MockIntersectionObserver.instances;
+      expect(fetchObs.options.rootMargin).toBe("50px");
+      expect(renderObs.options.rootMargin).toBe("100%");
+      warnSpy.mockRestore();
+    });
+
+    test("invalid margin throws with helpful context", () => {
+      const OrigMock = globalThis.IntersectionObserver;
+      globalThis.IntersectionObserver = class ThrowingObserver {
+        constructor(_cb: unknown, options: IntersectionObserverInit) {
+          throw new Error(
+            `rootMargin must be specified in pixels or percent: ${options.rootMargin}`,
+          );
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+        takeRecords() {
+          return [];
+        }
+      } as unknown as typeof IntersectionObserver;
+
+      const element = document.createElement("ad-unit") as AdUnit;
+      element.setAttribute("loading", "lazy");
+      element.setAttribute("code", "test-ad");
+      element.setAttribute("fetch-margin", "banana");
+
+      expect(() => container.appendChild(element)).toThrow(
+        '[ad-unit "test-ad"] Invalid fetch-margin "banana"',
+      );
+
+      globalThis.IntersectionObserver = OrigMock;
     });
   });
 });

--- a/src/ad-unit.ts
+++ b/src/ad-unit.ts
@@ -1,6 +1,31 @@
 import type { BannerFormat } from "./types";
 import { parseSizes, serializeSizes } from "./utils/parse-sizes";
 
+const DEFAULT_FETCH_MARGIN = "200%";
+const DEFAULT_RENDER_MARGIN = "150%";
+
+interface ParsedMargin {
+  value: number;
+  unit: "px" | "%";
+}
+
+function parseMargin(
+  margin: string,
+  label: string,
+  code: string,
+): ParsedMargin {
+  const match = margin.match(/^(-?\d+(?:\.\d+)?)(px|%)$/);
+  if (!match?.[1] || !match[2]) {
+    console.warn(
+      `[ad-unit "${code}"] Could not parse ${label} "${margin}" for comparison, expected a number followed by px or %. Falling back to default.`,
+    );
+    return label === "fetch-margin"
+      ? { value: 200, unit: "%" }
+      : { value: 150, unit: "%" };
+  }
+  return { value: Number.parseFloat(match[1]), unit: match[2] as "px" | "%" };
+}
+
 /**
  * AdUnit web component - declarative ad unit lifecycle manager
  *
@@ -20,6 +45,9 @@ import { parseSizes, serializeSizes } from "./utils/parse-sizes";
  * @attr pos - OpenRTB position (0=unknown, 1=ATF, 3=BTF, 4=header, 5=footer, 6=sidebar, 7=fullscreen)
  * @attr name - Banner name for debugging
  * @attr gpid - Global Placement ID for first-party data
+ * @attr loading - "eager" (default) or "lazy" for IntersectionObserver-based viewport detection
+ * @attr fetch-margin - rootMargin for the fetch zone observer (default "200%")
+ * @attr render-margin - rootMargin for the render zone observer (default "150%")
  */
 export class AdUnit extends HTMLElement {
   static observedAttributes = [
@@ -29,9 +57,16 @@ export class AdUnit extends HTMLElement {
     "gpid",
     "pos",
     "name",
+    "loading",
+    "fetch-margin",
+    "render-margin",
   ];
 
   #container: HTMLDivElement;
+  #fetchObserver: IntersectionObserver | null = null;
+  #renderObserver: IntersectionObserver | null = null;
+  #fetchFired = false;
+  #renderFired = false;
 
   constructor() {
     super();
@@ -171,15 +206,128 @@ export class AdUnit extends HTMLElement {
     }
   }
 
+  get loading(): string {
+    return this.getAttribute("loading") ?? "eager";
+  }
+
+  set loading(value: string) {
+    this.setAttribute("loading", value);
+  }
+
+  get fetchMargin(): string {
+    return this.getAttribute("fetch-margin") ?? DEFAULT_FETCH_MARGIN;
+  }
+
+  set fetchMargin(value: string) {
+    this.setAttribute("fetch-margin", value);
+  }
+
+  get renderMargin(): string {
+    return this.getAttribute("render-margin") ?? DEFAULT_RENDER_MARGIN;
+  }
+
+  set renderMargin(value: string) {
+    this.setAttribute("render-margin", value);
+  }
+
   // --- Lifecycle ---
 
   connectedCallback() {
     this.render();
     this.#dispatchLifecycle("ad-unit:connected");
+
+    if (this.loading === "lazy") {
+      this.#setupObservers();
+    } else {
+      this.#dispatchLifecycle("ad-unit:fetch");
+      this.#dispatchLifecycle("ad-unit:render");
+    }
   }
 
   disconnectedCallback() {
+    this.#teardownObservers();
     this.#dispatchLifecycle("ad-unit:disconnected");
+  }
+
+  #setupObservers() {
+    this.#fetchFired = false;
+    this.#renderFired = false;
+
+    let fetchMargin = this.fetchMargin;
+    const renderMargin = this.renderMargin;
+
+    const fetchParsed = parseMargin(fetchMargin, "fetch-margin", this.code);
+    const renderParsed = parseMargin(renderMargin, "render-margin", this.code);
+    if (
+      fetchParsed.unit === renderParsed.unit &&
+      fetchParsed.value < renderParsed.value
+    ) {
+      console.warn(
+        `[ad-unit "${this.code}"] fetch-margin (${fetchMargin}) is less than render-margin (${renderMargin}), clamping fetch-margin to render-margin`,
+      );
+      fetchMargin = renderMargin;
+    }
+
+    this.#fetchObserver = this.#createObserver(
+      fetchMargin,
+      "fetch-margin",
+      () => {
+        if (this.#fetchFired) return;
+        this.#fetchFired = true;
+        this.#fetchObserver?.unobserve(this);
+        this.#dispatchLifecycle("ad-unit:fetch");
+      },
+    );
+
+    this.#renderObserver = this.#createObserver(
+      renderMargin,
+      "render-margin",
+      () => {
+        if (this.#renderFired) return;
+        if (!this.#fetchFired) {
+          this.#fetchFired = true;
+          this.#fetchObserver?.unobserve(this);
+          this.#dispatchLifecycle("ad-unit:fetch");
+        }
+        this.#renderFired = true;
+        this.#renderObserver?.unobserve(this);
+        this.#dispatchLifecycle("ad-unit:render");
+      },
+    );
+
+    this.#fetchObserver.observe(this);
+    this.#renderObserver.observe(this);
+  }
+
+  #createObserver(
+    margin: string,
+    attrName: string,
+    onIntersect: () => void,
+  ): IntersectionObserver {
+    try {
+      return new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            if (entry.isIntersecting) {
+              onIntersect();
+              return;
+            }
+          }
+        },
+        { rootMargin: margin },
+      );
+    } catch (e) {
+      throw new Error(
+        `[ad-unit "${this.code}"] Invalid ${attrName} "${margin}": ${e instanceof Error ? e.message : e}`,
+      );
+    }
+  }
+
+  #teardownObservers() {
+    this.#fetchObserver?.disconnect();
+    this.#renderObserver?.disconnect();
+    this.#fetchObserver = null;
+    this.#renderObserver = null;
   }
 
   #dispatchLifecycle(type: string) {


### PR DESCRIPTION
### Summary

This pull request introduces lazy loading functionality for `ad-unit` elements using `IntersectionObserver`. 

### Details

- Implements `loading`, `fetch-margin`, and `render-margin` attributes to control lazy loading behavior.
- Validates margin inputs and integrates lifecycle updates.
- Ensures a fetch-before-render invariant when elements are in-view and lazy-loaded.
- Adds a design spec outlining lazy and eager loading modes, margin validation, event handling, and testing strategies.
- Includes comprehensive test coverage for all new functionality.

### Checks

- [ ] Reviewed the feature's impact on performance.
- [ ] Documented the new attributes and their usage.
- [ ] Tested across multiple browsers for compatibility.