### PR TITLE
Repo chores: license, package name, registry publishing (#14)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sam Evans
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ A vendor-agnostic `<ad-unit>` web component. Declare ad slots in HTML; external 
 ## Install
 
 ```bash
-bun install ad-unit-component
+npm install @ad-unit/core
 ```
 
 ## Usage
 
 ```html
 <script type="module">
-  import "ad-unit-component";
+  import "@ad-unit/core";
 </script>
 
 <ad-unit
@@ -48,7 +48,7 @@ ad-unit:connected → ad-unit:fetch → ad-unit:render
 Each event is an `AdUnitLifecycleEvent`. Listeners can hold progression to the next stage by calling `event.waitUntil(promise)`. Multiple listeners compose — all pending promises are awaited via `Promise.all` before the next event fires.
 
 ```ts
-import type { AdUnitLifecycleEvent } from "ad-unit-component";
+import type { AdUnitLifecycleEvent } from "@ad-unit/core";
 
 adUnit.addEventListener("ad-unit:fetch", (e) => {
   const event = e as AdUnitLifecycleEvent;

--- a/README.md
+++ b/README.md
@@ -68,6 +68,25 @@ With `loading="lazy"`, the component attaches internal `waitUntil` gates to `ad-
 - `ad-unit:stage-blocked` / `ad-unit:stage-unblocked` — transition events (`detail: { stage }`)
 - `ad-unit:error` — fires if any `waitUntil` promise rejects; halts the lifecycle (`detail: { stage, error }`)
 
+### Refresh
+
+Call `adUnit.refresh()` to trigger a new lifecycle cycle:
+
+```
+ad-unit:refresh → ad-unit:fetch → ad-unit:render
+```
+
+Refresh reuses the same `waitUntil` stage machinery as the initial connect, but bypasses lazy-loading viewport gates — it is an explicit trigger.
+
+```ts
+const adUnit = document.querySelector("ad-unit") as AdUnit;
+adUnit.refresh();
+```
+
+`adUnit.refreshCount` (readonly) increments before each `ad-unit:refresh` dispatch. The value is carried on every event's `detail.refreshCount`, so adapters can distinguish first-load (`0`) from the N-th refresh. If `refresh()` is called while a cycle is already in flight, the old cycle is aborted and a new one starts. Calling `refresh()` on a disconnected element is a no-op with a console warning.
+
+Scheduling, viewability-gated refresh, max-count caps, and auction batching are adapter concerns — the component exposes only the trigger primitive.
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ adUnit.refresh();
 
 Scheduling, viewability-gated refresh, max-count caps, and auction batching are adapter concerns — the component exposes only the trigger primitive.
 
+## Adapters
+
+`<ad-unit>` is vendor-agnostic. Vendor-specific behavior (Prebid, GAM, apstag) lives in external adapter packages that subscribe to lifecycle events and act on the component's public surface. The component never imports a vendor SDK.
+
+```ts
+// Example: a simple adapter that runs an auction on fetch
+document.addEventListener("ad-unit:fetch", (e) => {
+  const event = e as AdUnitLifecycleEvent;
+  event.waitUntil(runVendorAuction(event.detail));
+});
+```
+
+Adapter packages are in development — see the [adapter registry interface (#7)](https://github.com/evans-sam/ad-unit-component/issues/7), [GAM (#10)](https://github.com/evans-sam/ad-unit-component/issues/10), [Prebid (#11)](https://github.com/evans-sam/ad-unit-component/issues/11), and [apstag (#12)](https://github.com/evans-sam/ad-unit-component/issues/12).
+
 ## Development
 
 ```bash

--- a/docs/superpowers/specs/2026-04-15-repo-chores-design.md
+++ b/docs/superpowers/specs/2026-04-15-repo-chores-design.md
@@ -1,0 +1,99 @@
+# Repo Chores: License, Package Name, Registry Publishing
+
+Issue: [#14](https://github.com/evans-sam/ad-unit-component/issues/14)
+Date: 2026-04-15
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| License | MIT | Standard for JS/TS libraries; zero adoption friction |
+| Package name | `@ad-unit/core` | Scoped namespace for future adapter packages (`@ad-unit/prebid-adapter`, etc.) |
+| Registry | npm public | Standard for open-source; no consumer `.npmrc` config needed |
+| CONTRIBUTING.md | Deferred | Adapter interfaces (#7) not yet merged; add when there's concrete guidance for adapter authors |
+
+## Changes
+
+### 1. LICENSE file
+
+Add `LICENSE` at repo root with standard MIT text. Copyright line: `Copyright (c) 2026 Sam Evans`.
+
+### 2. package.json metadata
+
+Update the following fields:
+
+```jsonc
+{
+  "name": "@ad-unit/core",
+  "description": "Vendor-agnostic <ad-unit> web component — declare ad slots in HTML, handle vendor behavior through lifecycle event adapters",
+  "license": "MIT",
+  "author": "Sam Evans (https://github.com/evans-sam)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/evans-sam/ad-unit-component.git"
+  },
+  "keywords": [
+    "web-component",
+    "custom-element",
+    "ad-unit",
+    "advertising",
+    "prebid",
+    "gam",
+    "openrtb"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}
+```
+
+Fields left unchanged (already correct):
+- `version`: `0.1.0`
+- `files`: `["dist"]`
+- `exports`, `main`, `types` — already point at `dist/`
+- `type`: `"module"`
+
+### 3. README updates
+
+**Install command:** Change from `bun install ad-unit-component` to `npm install @ad-unit/core`.
+
+**Import path:** Change from `import "ad-unit-component"` to `import "@ad-unit/core"`.
+
+**Add refresh section:** Document the `refresh()` method and `ad-unit:refresh` event that shipped in issue #6. Brief usage example showing `adUnit.refresh()` and listening for the refresh event. Mention that `refreshCount` increments per call and is carried on event details.
+
+**Add adapter concept blurb:** Short paragraph after the lifecycle section explaining that vendor-specific behavior (Prebid, GAM, apstag) lives in external adapter packages that listen to lifecycle events. Note that adapter packages are coming soon (link to issues #10-12). This is the key architectural message for someone landing on the repo.
+
+**Type import example:** Update the lifecycle code example import from `import type { AdUnitLifecycleEvent } from "ad-unit-component"` to `import type { AdUnitLifecycleEvent } from "@ad-unit/core"`.
+
+### 4. No other file changes
+
+- `files` field already restricts the published package to `dist/` — no `.npmignore` needed.
+- Build config (`build.ts`) is unchanged; it already outputs to `dist/`.
+- No source files reference the package name internally.
+
+## Manual steps (package owner)
+
+These steps cannot be automated and must be done by the repo owner:
+
+1. **Create npm account** (if not already): [npmjs.com/signup](https://www.npmjs.com/signup)
+2. **Create `@ad-unit` org on npm**: [npmjs.com/org/create](https://www.npmjs.com/org/create) — free tier is sufficient for public packages
+3. **Authenticate**: Run `npm login` from terminal
+4. **Publish** (after code changes are merged and built): `bun run build && npm publish`
+
+## Out of scope
+
+- CONTRIBUTING.md — deferred until adapter registry (#7) ships
+- CI/CD publish automation — separate concern, not part of this issue
+- Adapter packages — issues #10, #11, #12
+- Version bumping strategy / changelogs — future concern
+
+## Acceptance criteria mapping
+
+| Criterion | Addressed by |
+|-----------|-------------|
+| LICENSE file added to repo root | Change 1 |
+| Package name decided and updated in package.json | Change 2 (`@ad-unit/core`) |
+| Registry target decided and documented | Decision table + manual steps section |
+| package.json metadata fields complete | Change 2 |
+| files field verified | Change 4 (already correct) |
+| README updated with current architecture and usage | Change 3 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,22 @@
 {
-  "name": "ad-unit-component",
+  "name": "@ad-unit/core",
   "version": "0.1.0",
+  "description": "Vendor-agnostic <ad-unit> web component — declare ad slots in HTML, handle vendor behavior through lifecycle event adapters",
+  "license": "MIT",
+  "author": "Sam Evans (https://github.com/evans-sam)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/evans-sam/ad-unit-component.git"
+  },
+  "keywords": [
+    "web-component",
+    "custom-element",
+    "ad-unit",
+    "advertising",
+    "prebid",
+    "gam",
+    "openrtb"
+  ],
   "module": "index.ts",
   "type": "module",
   "main": "dist/index.js",
@@ -38,5 +54,8 @@
   },
   "peerDependencies": {
     "typescript": "^5"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

- Add MIT license file
- Rename package from `ad-unit-component` to `@ad-unit/core` with full npm metadata (description, keywords, repository, author, publishConfig)
- Update README install/import paths to `@ad-unit/core`
- Add `refresh()` documentation section to README
- Add adapters concept section to README explaining the vendor-agnostic architecture

## Test plan

- [x] `bun run build` — clean
- [x] `bun test` — 154 pass, 0 fail
- [x] `bun run lint` — no issues
- [x] `npm pack --dry-run` — shows `@ad-unit/core@0.1.0`, includes only LICENSE, README.md, dist/, package.json

Closes #14