### PR TITLE
Set up CI/CD pipeline (#15)

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,45 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "Features"
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: "Bug Fixes"
+    labels:
+      - "bug"
+      - "fix"
+  - title: "Maintenance"
+    labels:
+      - "chore"
+      - "maintenance"
+      - "dependencies"
+      - "ci"
+
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+change-title-escapes: '\<*_&'
+no-changes-template: "No changes since last release."
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+
+template: |
+  ## What Changed
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: Lint, Test & Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Browser-compat lint
+        run: bun run lint:compat
+
+      - name: Typecheck
+        run: bunx tsc --noEmit
+
+      - name: Test with coverage
+        run: bun test --coverage
+
+      - name: Build
+        run: bun run build
+
+      - name: Verify build artifacts
+        run: |
+          test -f dist/index.js || { echo "dist/index.js missing"; exit 1; }
+          test -f dist/index.d.ts || { echo "dist/index.d.ts missing"; exit 1; }
+          test -s dist/index.js || { echo "dist/index.js is empty"; exit 1; }
+          test -s dist/index.d.ts || { echo "dist/index.d.ts is empty"; exit 1; }

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,25 @@
+name: Dependency Audit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Vulnerability Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Audit dependencies
+        run: bun audit --audit-level=high

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          registry-url: https://registry.npmjs.org
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run build
+
+      - run: npm publish --provenance

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  draft:
+    name: Update Draft Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "ad-unit-component",
       "devDependencies": {
         "@biomejs/biome": "^2.3.10",
-        "@happy-dom/global-registrator": "^20.0.11",
+        "@happy-dom/global-registrator": "^20.9.0",
         "@types/bun": "latest",
         "eslint-plugin-compat": "^7.0.1",
         "lefthook": "^2.0.13",
@@ -50,7 +50,7 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.1", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ=="],
 
-    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.11", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.11" } }, "sha512-GqNqiShBT/lzkHTMC/slKBrvN0DsD4Di8ssBk4aDaVgEn+2WMzE6DXxq701ndSXj7/0cJ8mNT71pM7Bnrr6JRw=="],
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.9.0" } }, "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -108,9 +108,11 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@20.19.27", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug=="],
+    "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -139,6 +141,8 @@
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.336", "", {}, "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -180,7 +184,7 @@
 
     "globals": ["globals@15.15.0", "", {}, "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg=="],
 
-    "happy-dom": ["happy-dom@20.0.11", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-QsCdAUHAmiDeKeaNojb1OHOPF7NjcWPBR7obdu3NwH2a/oyQaLg5d0aaCy/9My6CdPChYF07dvz5chaXBGaD4g=="],
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -264,7 +268,7 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
@@ -276,14 +280,12 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "ast-metadata-inferer/@mdn/browser-compat-data": ["@mdn/browser-compat-data@5.7.6", "", {}, "sha512-7xdrMX0Wk7grrTZQwAoy1GkvPMFoizStUoL+VmtUkAxegbCCec+3FKwOM6yc/uGU5+BEczQHXAlWiqvM8JeENg=="],
-
-    "bun-types/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
-
-    "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }
 }

--- a/docs/superpowers/specs/2026-04-15-cicd-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-15-cicd-pipeline-design.md
@@ -27,16 +27,18 @@ GitHub Actions CI/CD for `@ad-unit/core`. Four focused workflow files, each with
 
 Coverage is reported in CI logs only. PR comment reporting is deferred.
 
-### 2. Dependency Review (`dependency-review.yml`)
+### 2. Dependency Audit (`dependency-audit.yml`)
 
-**Trigger:** `pull_request` only
+**Triggers:** `pull_request` (all branches) + `push` to `main`
 
 **Single job — steps:**
 
 1. `actions/checkout`
-2. `actions/dependency-review-action` — fails if new dependencies introduce known vulnerabilities (critical + high severity)
+2. `oven-sh/setup-bun`
+3. `bun install --frozen-lockfile`
+4. `bun audit --audit-level=high` — scans ALL transitive dependencies against the GitHub Advisory Database, exits 1 on high/critical vulnerabilities
 
-Runs as a separate required status check, independently visible in the PR checks list. Guards against supply chain attacks on dependency changes.
+Runs on every PR and push to main. Catches new CVEs against existing deps even when no dependencies changed. Required status check blocks merging.
 
 ### 3. Release Drafter (`release-drafter.yml`)
 
@@ -79,7 +81,7 @@ Rebuilds from the tagged commit rather than caching artifacts from CI. This ensu
 | Path | Purpose |
 |---|---|
 | `.github/workflows/ci.yml` | Lint, typecheck, test, build |
-| `.github/workflows/dependency-review.yml` | Vulnerability audit on PRs |
+| `.github/workflows/dependency-audit.yml` | Full dependency vulnerability scan |
 | `.github/workflows/release-drafter.yml` | Auto-update draft release on PR merge |
 | `.github/workflows/publish.yml` | Publish to npm on release |
 | `.github/release-drafter.yml` | Release drafter category/version config |
@@ -88,7 +90,7 @@ Rebuilds from the tagged commit rather than caching artifacts from CI. This ensu
 
 After workflows are merged, enable branch protection on `main`:
 
-- Require status checks to pass: `ci`, `dependency-review`
+- Require status checks to pass: `ci`, `dependency-audit`
 - Require branches to be up to date before merging
 
 This is a manual step in GitHub repo settings, not automated by the workflows.
@@ -107,5 +109,5 @@ This is a manual step in GitHub repo settings, not automated by the workflows.
 | Publish trigger | `release: published` | Covers both draft-publish and direct release creation |
 | npm auth | Trusted publishing (OIDC) | No long-lived tokens, more secure |
 | Release drafting | `release-drafter/release-drafter` | Standard pattern, auto-accumulates PR changes |
-| Dependency audit | `github/dependency-review-action` | GitHub-native, works without `bun audit` |
+| Dependency audit | `bun audit --audit-level=high` | Scans all deps against GitHub Advisory DB, native to Bun |
 | Coverage reporting | Console output only | Simple; PR comments deferred |

--- a/docs/superpowers/specs/2026-04-15-cicd-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-15-cicd-pipeline-design.md
@@ -1,0 +1,111 @@
+# CI/CD Pipeline Design
+
+**Issue:** [#15 — Set up CI/CD pipeline](https://github.com/evans-sam/ad-unit-component/issues/15)
+**Date:** 2026-04-15
+
+## Overview
+
+GitHub Actions CI/CD for `@ad-unit/core`. Four focused workflow files, each with a single responsibility. All workflows use Bun as the runtime — no Node for build/test/lint steps.
+
+## Workflow Files
+
+### 1. CI (`ci.yml`)
+
+**Triggers:** `pull_request` (all branches) + `push` to `main`
+
+**Single job — steps in order:**
+
+1. `actions/checkout`
+2. `oven-sh/setup-bun` (pin `bun-version: 1.x`)
+3. `bun install --frozen-lockfile`
+4. `bun run lint` — Biome check
+5. `bun run lint:compat` — oxlint browser-compat lint
+6. `tsc --noEmit` — type check
+7. `bun test --coverage` — tests with coverage output to console
+8. `bun run build` — bundle JS + emit declarations to `dist/`
+9. Verify build artifacts — run a Node/Bun script that asserts `dist/index.js` and `dist/index.d.ts` exist on disk and that `import("./dist/index.js")` resolves without throwing
+
+Coverage is reported in CI logs only. PR comment reporting is deferred.
+
+### 2. Dependency Review (`dependency-review.yml`)
+
+**Trigger:** `pull_request` only
+
+**Single job — steps:**
+
+1. `actions/checkout`
+2. `actions/dependency-review-action` — fails if new dependencies introduce known vulnerabilities (critical + high severity)
+
+Runs as a separate required status check, independently visible in the PR checks list. Guards against supply chain attacks on dependency changes.
+
+### 3. Release Drafter (`release-drafter.yml`)
+
+**Trigger:** `push` to `main` (PR merges)
+
+**Uses:** `release-drafter/release-drafter`
+
+**Config file:** `.github/release-drafter.yml`
+
+- Categorizes PRs by label: Features, Bug Fixes, Maintenance/Chores
+- Version resolver based on labels: `major`, `minor`, `patch` (defaults to `patch`)
+- Template includes contributor list and full changelog link
+- Tag format: `v$RESOLVED_VERSION` (e.g., `v0.2.0`)
+
+The draft accumulates as PRs merge. To release: review/edit the draft in GitHub Releases, then publish. Publishing creates the tag and triggers the publish workflow.
+
+No Bun setup needed — purely a GitHub API operation.
+
+### 4. Publish (`publish.yml`)
+
+**Trigger:** `release: published`
+
+**Permissions:** `contents: read`, `id-token: write` (OIDC for npm trusted publishing)
+
+**Single job — steps:**
+
+1. `actions/checkout` (at the release tag)
+2. `oven-sh/setup-bun`
+3. `actions/setup-node` — needed for npm registry auth via OIDC
+4. `bun install --frozen-lockfile`
+5. `bun run build`
+6. `npm publish --provenance` — authenticated via OIDC, no NPM_TOKEN secret
+
+Rebuilds from the tagged commit rather than caching artifacts from CI. This ensures the published package matches exactly what's tagged.
+
+**Prerequisites:** Trusted publisher must be configured on npmjs.com, linking `evans-sam/ad-unit-component` repo and the `publish.yml` workflow.
+
+## Files Created
+
+| Path | Purpose |
+|---|---|
+| `.github/workflows/ci.yml` | Lint, typecheck, test, build |
+| `.github/workflows/dependency-review.yml` | Vulnerability audit on PRs |
+| `.github/workflows/release-drafter.yml` | Auto-update draft release on PR merge |
+| `.github/workflows/publish.yml` | Publish to npm on release |
+| `.github/release-drafter.yml` | Release drafter category/version config |
+
+## Branch Protection
+
+After workflows are merged, enable branch protection on `main`:
+
+- Require status checks to pass: `ci`, `dependency-review`
+- Require branches to be up to date before merging
+
+This is a manual step in GitHub repo settings, not automated by the workflows.
+
+## Deferred
+
+- **Bundle size reporting** — library will always be small; not needed now
+- **Coverage PR comments** — coverage output is in CI logs for now
+- **`bun publish`** — Bun's publish is still experimental; using `npm publish` with provenance
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Workflow structure | 4 separate files | Clear ownership, scoped permissions, easy to debug |
+| Publish trigger | `release: published` | Covers both draft-publish and direct release creation |
+| npm auth | Trusted publishing (OIDC) | No long-lived tokens, more secure |
+| Release drafting | `release-drafter/release-drafter` | Standard pattern, auto-accumulates PR changes |
+| Dependency audit | `github/dependency-review-action` | GitHub-native, works without `bun audit` |
+| Coverage reporting | Console output only | Simple; PR comments deferred |

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.10",
-    "@happy-dom/global-registrator": "^20.0.11",
+    "@happy-dom/global-registrator": "^20.9.0",
     "@types/bun": "latest",
     "eslint-plugin-compat": "^7.0.1",
     "lefthook": "^2.0.13",


### PR DESCRIPTION
## Summary

- Adds 4 GitHub Actions workflows: CI (lint, typecheck, test, build), dependency audit (`bun audit`), release drafter, and npm publish via OIDC trusted publishing
- Fixes 2 high-severity vulnerabilities in `happy-dom` by updating to 20.9.0
- All workflows use Bun — no Node except for npm registry OIDC auth in the publish workflow

## Workflows

| Workflow | Trigger | Purpose |
|---|---|---|
| `ci.yml` | PR + push to main | Lint, typecheck, test with coverage, build, verify artifacts |
| `dependency-audit.yml` | PR + push to main | Full dependency vulnerability scan via `bun audit --audit-level=high` |
| `release-drafter.yml` | Push to main | Auto-update draft release with categorized PR changes |
| `publish.yml` | Release published | Publish to npm with OIDC provenance (no NPM_TOKEN needed) |

## Post-merge manual steps

- Enable branch protection on `main`: require `ci` and `dependency-audit` status checks
- Configure trusted publisher on npmjs.com for `@ad-unit/core`

## Test plan

- [ ] CI workflow triggers on this PR and all steps pass
- [ ] Dependency audit workflow triggers and passes (0 vulnerabilities after happy-dom update)
- [ ] After merge, release-drafter creates a draft release
- [ ] Verify publish workflow syntax (full test requires npm trusted publisher config)

Closes #15