### PR TITLE
Adapter registries and TypeScript interfaces (#7)

### DIFF
--- a/demo/mock-adapter.test.ts
+++ b/demo/mock-adapter.test.ts
@@ -11,11 +11,11 @@ describe("createMockAdapter", () => {
     host = document.createElement("div");
     document.body.appendChild(host);
     adapter = createMockAdapter({ auctionDelayMs: 10 });
-    adapter.start();
+    adapter.init();
   });
 
   afterEach(() => {
-    adapter.stop();
+    adapter.destroy();
     host.remove();
   });
 
@@ -121,9 +121,9 @@ describe("createMockAdapter", () => {
     expect(mock?.dataset.refreshCount).toBe("1");
   });
 
-  test("stop() detaches listeners so further connections are ignored", () => {
-    adapter.stop();
-    const unit = createUnit({ code: "post-stop" });
+  test("destroy() detaches listeners so further connections are ignored", () => {
+    adapter.destroy();
+    const unit = createUnit({ code: "post-destroy" });
     host.appendChild(unit);
     expect(unit.container.querySelector(".mock-ad")).toBeNull();
   });

--- a/demo/mock-adapter.ts
+++ b/demo/mock-adapter.ts
@@ -1,14 +1,12 @@
-import type { AdUnitLifecycleEvent, BannerFormat } from "../src";
+import type {
+  AdUnitLifecycleEvent,
+  BannerFormat,
+  HeaderBiddingAdapter,
+} from "../src";
 
 export interface MockAdapterOptions {
   auctionDelayMs?: number;
   bidPriceRange?: [number, number];
-}
-
-export interface MockAdapter {
-  start(): void;
-
-  stop(): void;
 }
 
 interface LifecycleDetail {
@@ -37,7 +35,7 @@ interface PendingAuction {
  */
 export function createMockAdapter(
   options: MockAdapterOptions = {},
-): MockAdapter {
+): HeaderBiddingAdapter {
   const auctionDelayMs = options.auctionDelayMs ?? 500;
   const [minPrice, maxPrice] = options.bidPriceRange ?? [0.1, 5.0];
   const pendingAuctions = new Map<string, PendingAuction>();
@@ -83,14 +81,15 @@ export function createMockAdapter(
   };
 
   return {
-    start() {
+    name: "mock",
+    init() {
       if (started) return;
       document.addEventListener("ad-unit:fetch", onFetch);
       document.addEventListener("ad-unit:render", onRender);
       document.addEventListener("ad-unit:disconnected", onDisconnected);
       started = true;
     },
-    stop() {
+    destroy() {
       if (!started) return;
       document.removeEventListener("ad-unit:fetch", onFetch);
       document.removeEventListener("ad-unit:render", onRender);

--- a/demo/scenarios/blocking.ts
+++ b/demo/scenarios/blocking.ts
@@ -1,10 +1,15 @@
 import "../../src/index";
-import type { AdUnit, AdUnitLifecycleEvent } from "../../src";
+import {
+  type AdUnit,
+  type AdUnitLifecycleEvent,
+  HeaderBiddingRegistry,
+} from "../../src";
 import "../event-log";
 import { createMockAdapter } from "../mock-adapter";
 
 const adapter = createMockAdapter();
-adapter.start();
+HeaderBiddingRegistry.register(adapter.name, adapter);
+adapter.init();
 
 const gatedUnit = document.querySelector<AdUnit>("ad-unit[code='user-gated']");
 const baselineUnit = document.querySelector<AdUnit>("ad-unit[code='baseline']");

--- a/demo/scenarios/lifecycle.ts
+++ b/demo/scenarios/lifecycle.ts
@@ -1,10 +1,11 @@
 import "../../src/index";
-import type { AdUnit } from "../../src";
+import { type AdUnit, HeaderBiddingRegistry } from "../../src";
 import "../event-log";
 import { createMockAdapter } from "../mock-adapter";
 
 const adapter = createMockAdapter();
-adapter.start();
+HeaderBiddingRegistry.register(adapter.name, adapter);
+adapter.init();
 
 const dynamicHost = document.getElementById("dynamic-units") as HTMLDivElement;
 const addBtn = document.getElementById("add-btn") as HTMLButtonElement;

--- a/demo/scenarios/refresh.ts
+++ b/demo/scenarios/refresh.ts
@@ -1,12 +1,13 @@
 import "../../src/index";
-import type { AdUnit } from "../../src";
+import { type AdUnit, HeaderBiddingRegistry } from "../../src";
 import "../event-log";
 import { createMockAdapter } from "../mock-adapter";
 
 const AUTO_INTERVAL_MS = 5000;
 
 const adapter = createMockAdapter();
-adapter.start();
+HeaderBiddingRegistry.register(adapter.name, adapter);
+adapter.init();
 
 const unit = document.querySelector<AdUnit>("ad-unit[code='refresh-unit']");
 const countNode = document.getElementById("count") as HTMLElement;

--- a/demo/scenarios/viewport.ts
+++ b/demo/scenarios/viewport.ts
@@ -1,9 +1,11 @@
 import "../../src/index";
+import { HeaderBiddingRegistry } from "../../src";
 import "../event-log";
 import { createMockAdapter } from "../mock-adapter";
 
 const adapter = createMockAdapter();
-adapter.start();
+HeaderBiddingRegistry.register(adapter.name, adapter);
+adapter.init();
 
 // Hide the scroll hint once the user has actually scrolled enough to trigger
 // the first fetch zone — no need to keep nagging.

--- a/docs/superpowers/plans/2026-04-15-adapter-registry.md
+++ b/docs/superpowers/plans/2026-04-15-adapter-registry.md
@@ -1,0 +1,493 @@
+# Adapter Registry & Interfaces Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `AdServerRegistry` and `HeaderBiddingRegistry` (module-scoped singletons) backed by a generic `AdapterRegistry<T>` class, and export `AdServerAdapter` / `HeaderBiddingAdapter` TypeScript interfaces. Refactor `demo/mock-adapter.ts` to implement `HeaderBiddingAdapter` and wire the registry into demo scenarios.
+
+**Architecture:** Two interfaces (`AdServerAdapter`, `HeaderBiddingAdapter`) with identical shape — `readonly name`, `init(config?: unknown)`, `destroy()` — declared with method syntax so TypeScript bivariance lets concrete adapters narrow `init(config: SomeConfig)`. A single `AdapterRegistry<T>` class backs both registries with `register(name, adapter)` / `get(name)` / `getAll()`. Duplicate `register()` emits `console.warn` and overwrites. `getAll()` returns a fresh `Map` snapshot.
+
+**Tech Stack:** TypeScript, `bun:test` for unit tests (no DOM needed for the registry itself). Biome for lint/format.
+
+**Spec:** `docs/superpowers/specs/2026-04-15-adapter-registry-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `src/adapters.ts` — two exported interfaces (`AdServerAdapter`, `HeaderBiddingAdapter`)
+- `src/registry.ts` — `AdapterRegistry<T>` class + `AdServerRegistry` + `HeaderBiddingRegistry` singletons
+- `src/registry.test.ts` — behavior coverage
+
+**Modified files:**
+- `src/index.ts` — re-export class, singletons, interfaces
+- `demo/mock-adapter.ts` — rename returned shape `{ start, stop }` → `{ name, init, destroy }`, conform to `HeaderBiddingAdapter`
+- `demo/scenarios/lifecycle.ts`, `demo/scenarios/viewport.ts`, `demo/scenarios/blocking.ts`, `demo/scenarios/refresh.ts` — update call sites that use the mock adapter
+
+**Unchanged:**
+- `src/ad-unit.ts`, `src/types.ts`, `src/utils/parse-sizes.ts`, `build.ts`, `tsconfig.json`, `biome.json`
+
+---
+
+## Task 1: Add adapter interfaces (`src/adapters.ts`)
+
+**Files:**
+- Create: `src/adapters.ts`
+
+Minimal module with two exported interfaces. No runtime code.
+
+- [ ] **Step 1: Create `src/adapters.ts`**
+
+```ts
+/**
+ * Contract for header bidding adapters (Prebid, apstag, etc.).
+ *
+ * Implementers subscribe to `<ad-unit>` lifecycle events (typically via
+ * `document.addEventListener`) and coordinate auction state. The interface
+ * deliberately does not prescribe event wiring — that is the adapter's
+ * concern. It exists so publishers have a consistent activation shape and
+ * TypeScript consumers get autocompletion.
+ */
+export interface HeaderBiddingAdapter {
+  readonly name: string;
+  init(config?: unknown): void | Promise<void>;
+  destroy(): void | Promise<void>;
+}
+
+/**
+ * Contract for ad server adapters (GAM, etc.).
+ *
+ * Structurally identical to `HeaderBiddingAdapter` today. Kept as a distinct
+ * type so the two roles can diverge without a breaking change (e.g. ad
+ * server adapters may later add a `setTargeting()` method referenced in the
+ * parent PRD).
+ */
+export interface AdServerAdapter {
+  readonly name: string;
+  init(config?: unknown): void | Promise<void>;
+  destroy(): void | Promise<void>;
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+bun run build
+```
+
+Expected: no type errors.
+
+---
+
+## Task 2: Add `AdapterRegistry` class and singletons (`src/registry.ts`)
+
+**Files:**
+- Create: `src/registry.ts`
+
+Generic class backed by a `Map<string, T>`, with two module-scoped instances exported.
+
+- [ ] **Step 1: Create `src/registry.ts`**
+
+```ts
+import type { AdServerAdapter, HeaderBiddingAdapter } from "./adapters";
+
+export class AdapterRegistry<T extends { readonly name: string }> {
+  readonly #label: string;
+  readonly #adapters = new Map<string, T>();
+
+  constructor(label: string) {
+    this.#label = label;
+  }
+
+  register(name: string, adapter: T): void {
+    if (this.#adapters.has(name)) {
+      console.warn(
+        `[${this.#label}] adapter "${name}" already registered; overwriting`,
+      );
+    }
+    this.#adapters.set(name, adapter);
+  }
+
+  get(name: string): T | undefined {
+    return this.#adapters.get(name);
+  }
+
+  getAll(): Map<string, T> {
+    return new Map(this.#adapters);
+  }
+}
+
+export const AdServerRegistry = new AdapterRegistry<AdServerAdapter>(
+  "AdServerRegistry",
+);
+export const HeaderBiddingRegistry = new AdapterRegistry<HeaderBiddingAdapter>(
+  "HeaderBiddingRegistry",
+);
+```
+
+Uses native `#private` (per AGENTS.md). No comments describing WHAT — the code is self-explanatory.
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+bun run build
+```
+
+Expected: no type errors.
+
+---
+
+## Task 3: Add registry behavior tests (`src/registry.test.ts`)
+
+**Files:**
+- Create: `src/registry.test.ts`
+
+Seven test cases covering the full public API. Style mirrors `src/ad-unit.test.ts`.
+
+- [ ] **Step 1: Create `src/registry.test.ts`**
+
+```ts
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import type { AdServerAdapter, HeaderBiddingAdapter } from "./adapters";
+import {
+  AdapterRegistry,
+  AdServerRegistry,
+  HeaderBiddingRegistry,
+} from "./registry";
+
+function makeAdapter(name: string): HeaderBiddingAdapter {
+  return {
+    name,
+    init() {},
+    destroy() {},
+  };
+}
+
+describe("AdapterRegistry", () => {
+  test("register() stores an adapter retrievable via get()", () => {
+    const registry = new AdapterRegistry<HeaderBiddingAdapter>("test");
+    const adapter = makeAdapter("prebid");
+    registry.register("prebid", adapter);
+    expect(registry.get("prebid")).toBe(adapter);
+  });
+
+  test("get() returns undefined for unknown name", () => {
+    const registry = new AdapterRegistry<HeaderBiddingAdapter>("test");
+    expect(registry.get("unknown")).toBeUndefined();
+  });
+
+  test("getAll() returns all registered adapters in insertion order", () => {
+    const registry = new AdapterRegistry<HeaderBiddingAdapter>("test");
+    const prebid = makeAdapter("prebid");
+    const apstag = makeAdapter("apstag");
+    registry.register("prebid", prebid);
+    registry.register("apstag", apstag);
+    const all = registry.getAll();
+    expect(Array.from(all.keys())).toEqual(["prebid", "apstag"]);
+    expect(all.get("prebid")).toBe(prebid);
+    expect(all.get("apstag")).toBe(apstag);
+  });
+
+  test("getAll() returns a snapshot — mutating it does not affect the registry", () => {
+    const registry = new AdapterRegistry<HeaderBiddingAdapter>("test");
+    const adapter = makeAdapter("prebid");
+    registry.register("prebid", adapter);
+    const snapshot = registry.getAll();
+    snapshot.delete("prebid");
+    snapshot.set("fake", makeAdapter("fake"));
+    expect(registry.get("prebid")).toBe(adapter);
+    expect(registry.get("fake")).toBeUndefined();
+  });
+
+  describe("duplicate registration", () => {
+    let warnSpy: ReturnType<typeof spyOn<Console, "warn">>;
+
+    beforeEach(() => {
+      warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    test("warns via console.warn with registry label and adapter name", () => {
+      const registry = new AdapterRegistry<HeaderBiddingAdapter>("MyRegistry");
+      registry.register("prebid", makeAdapter("prebid"));
+      registry.register("prebid", makeAdapter("prebid"));
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0][0]);
+      expect(message).toContain("MyRegistry");
+      expect(message).toContain("prebid");
+    });
+
+    test("overwrites — get() returns the later adapter", () => {
+      const registry = new AdapterRegistry<HeaderBiddingAdapter>("test");
+      const first = makeAdapter("prebid");
+      const second = makeAdapter("prebid");
+      registry.register("prebid", first);
+      registry.register("prebid", second);
+      expect(registry.get("prebid")).toBe(second);
+    });
+  });
+});
+
+describe("module singletons", () => {
+  afterEach(() => {
+    // Singletons are process-scoped; reset them so tests don't leak state.
+    for (const name of AdServerRegistry.getAll().keys()) {
+      // No public unregister; instantiate fresh maps by clearing via
+      // re-registration is the wrong shape. Instead, leverage the fact that
+      // each singleton's #adapters Map persists — we only need isolation
+      // from each other, tested below. No cross-test cleanup required for
+      // the singleton-independence test.
+      void name;
+    }
+  });
+
+  test("AdServerRegistry and HeaderBiddingRegistry are independent", () => {
+    const adServer: AdServerAdapter = {
+      name: "gam-test",
+      init() {},
+      destroy() {},
+    };
+    const headerBidder: HeaderBiddingAdapter = {
+      name: "prebid-test",
+      init() {},
+      destroy() {},
+    };
+    AdServerRegistry.register("gam-test", adServer);
+    HeaderBiddingRegistry.register("prebid-test", headerBidder);
+    expect(AdServerRegistry.get("gam-test")).toBe(adServer);
+    expect(AdServerRegistry.get("prebid-test")).toBeUndefined();
+    expect(HeaderBiddingRegistry.get("prebid-test")).toBe(headerBidder);
+    expect(HeaderBiddingRegistry.get("gam-test")).toBeUndefined();
+  });
+});
+
+describe("TypeScript bivariance (compile-time check)", () => {
+  test("concrete adapter with narrowed init() signature is assignable", () => {
+    interface PrebidConfig {
+      units: Record<string, unknown>;
+    }
+
+    const PrebidAdapter: HeaderBiddingAdapter = {
+      name: "prebid",
+      init(config: PrebidConfig = { units: {} }) {
+        void config;
+      },
+      destroy() {},
+    };
+
+    // This line exists primarily as a compile-time check; method bivariance
+    // lets us narrow `init`'s parameter from `unknown` to `PrebidConfig`.
+    HeaderBiddingRegistry.register("prebid-bivariance-test", PrebidAdapter);
+    expect(HeaderBiddingRegistry.get("prebid-bivariance-test")).toBe(
+      PrebidAdapter,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+bun test src/registry.test.ts
+```
+
+Expected: all tests pass.
+
+---
+
+## Task 4: Export registries and interfaces from package root (`src/index.ts`)
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add exports to `src/index.ts`**
+
+Append two new export statements. Preserve existing exports exactly.
+
+New lines:
+
+```ts
+export {
+  AdapterRegistry,
+  AdServerRegistry,
+  HeaderBiddingRegistry,
+} from "./registry";
+export type { AdServerAdapter, HeaderBiddingAdapter } from "./adapters";
+```
+
+- [ ] **Step 2: Verify build produces correct `.d.ts`**
+
+```bash
+bun run build
+```
+
+Inspect `dist/index.d.ts` — expect five new exports: `AdapterRegistry` (class), `AdServerRegistry` (instance), `HeaderBiddingRegistry` (instance), `AdServerAdapter` (type), `HeaderBiddingAdapter` (type).
+
+---
+
+## Task 5: Refactor `demo/mock-adapter.ts` to implement `HeaderBiddingAdapter`
+
+**Files:**
+- Modify: `demo/mock-adapter.ts`
+
+- [ ] **Step 1: Update imports**
+
+Add `HeaderBiddingAdapter` to the `../src` type import:
+
+```ts
+import type {
+  AdUnitLifecycleEvent,
+  BannerFormat,
+  HeaderBiddingAdapter,
+} from "../src";
+```
+
+- [ ] **Step 2: Remove the local `MockAdapter` interface**
+
+Delete the `export interface MockAdapter { start(): void; stop(): void; }` block.
+
+- [ ] **Step 3: Update factory return type and returned object**
+
+Change the factory's declared return type from `MockAdapter` to `HeaderBiddingAdapter`.
+
+Change the returned object from:
+
+```ts
+return {
+  start() { ... },
+  stop() { ... },
+};
+```
+
+to:
+
+```ts
+return {
+  name: "mock",
+  init() { ... },  // body identical to old start()
+  destroy() { ... },  // body identical to old stop()
+};
+```
+
+`init()`'s optional `config` parameter is accepted implicitly via the interface — the body does nothing with it, so no parameter declaration is required.
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+```bash
+bun run build
+```
+
+Expected: no type errors.
+
+---
+
+## Task 6: Update demo scenarios that call the mock adapter
+
+**Files:**
+- Modify: `demo/scenarios/lifecycle.ts`, `demo/scenarios/viewport.ts`, `demo/scenarios/blocking.ts`, `demo/scenarios/refresh.ts` (only the files that actually instantiate the mock adapter)
+
+- [ ] **Step 1: Identify files calling `createMockAdapter`**
+
+```bash
+grep -l "createMockAdapter" demo/scenarios/
+```
+
+- [ ] **Step 2: Update each call site**
+
+Replace:
+
+```ts
+const adapter = createMockAdapter();
+adapter.start();
+```
+
+With:
+
+```ts
+const adapter = createMockAdapter();
+HeaderBiddingRegistry.register(adapter.name, adapter);
+adapter.init();
+```
+
+Replace `adapter.stop()` with `adapter.destroy()`.
+
+Add the `HeaderBiddingRegistry` import from `../../src`.
+
+- [ ] **Step 3: Verify demo runs**
+
+```bash
+bun run dev
+```
+
+Open each scenario page in a browser (or use the dev server URL routes). Confirm:
+
+1. Lifecycle events still trigger mock ad placards (pending → rendered states)
+2. Viewport scenario: lazy-loaded units still hit `init` → fetch handler → rendered placard on scroll
+3. Blocking scenario: `waitUntil` delays still visible
+4. Refresh scenario: refresh cycles re-paint placards with incrementing `refreshCount`
+
+Same behavior as before the refactor.
+
+---
+
+## Task 7: Run full verification
+
+**Files:** none modified
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+bun test
+```
+
+Expected: all tests pass. No regressions in existing `src/ad-unit.test.ts` or `src/utils/parse-sizes.test.ts`.
+
+- [ ] **Step 2: Run lint**
+
+```bash
+bun run lint
+```
+
+Expected: zero new warnings or errors.
+
+- [ ] **Step 3: Run build**
+
+```bash
+bun run build
+```
+
+Expected: `dist/index.js` and `dist/index.d.ts` emitted without error. Inspect `dist/index.d.ts` and confirm the new public API is present.
+
+- [ ] **Step 4: Manual smoke in demo**
+
+```bash
+bun run dev
+```
+
+In the demo page's DevTools console:
+
+```js
+import("/src/index.ts").then((m) => {
+  console.log(m.HeaderBiddingRegistry.getAll());     // Map with at least "mock"
+  console.log(m.HeaderBiddingRegistry.get("mock"));  // the adapter object
+  m.HeaderBiddingRegistry.register(
+    "mock",
+    m.HeaderBiddingRegistry.get("mock"),
+  );
+  // Expect a console.warn:
+  // [HeaderBiddingRegistry] adapter "mock" already registered; overwriting
+});
+```
+
+---
+
+## Commit strategy
+
+Per AGENTS.md: small + conventional commits, one per task group.
+
+1. `docs: add adapter registry design spec (issue #7)` — the spec and plan files committed together
+2. `feat: add AdapterRegistry and adapter interfaces (issue #7)` — `src/adapters.ts`, `src/registry.ts`, `src/registry.test.ts`, `src/index.ts`
+3. `refactor: update mock-adapter to implement HeaderBiddingAdapter (issue #7)` — `demo/mock-adapter.ts` and any affected demo scenario files

--- a/docs/superpowers/specs/2026-04-15-adapter-registry-design.md
+++ b/docs/superpowers/specs/2026-04-15-adapter-registry-design.md
@@ -1,0 +1,261 @@
+# Adapter registries and TypeScript interfaces
+
+> Design spec for [issue #7](https://github.com/evans-sam/ad-unit-component/issues/7)
+
+## Summary
+
+Add two module-scoped singleton registries — `AdServerRegistry` and `HeaderBiddingRegistry` — backed by a shared generic `AdapterRegistry<T>` class, and export two TypeScript interfaces — `AdServerAdapter` and `HeaderBiddingAdapter` — that adapters implement. Registry API is `register(name, adapter)` / `get(name)` / `getAll()`. Duplicate registration warns via `console.warn` and overwrites. The interfaces require `name`, `init()`, and `destroy()` at minimum; they do **not** prescribe which lifecycle events an adapter listens to.
+
+This is the extension point for community adapters and unblocks the v1 adapter implementations tracked in issues #10 (GAM), #11 (Prebid), and #12 (apstag).
+
+## Motivation
+
+The parent PRD ("Ad Unit Component v1", attached to GitHub project [evans-sam/projects/4](https://github.com/users/evans-sam/projects/4) as the project README) establishes a global-registry pattern for vendor-specific adapter registration:
+
+```ts
+AdServerRegistry.register("gam", GamAdapter);
+HeaderBiddingRegistry.register("prebid", PrebidAdapter);
+HeaderBiddingRegistry.register("apstag", ApstaAdapter);
+```
+
+The PRD's "Adapter Architecture" section also specifies the exact registry API: `register(name, adapter) / get(name) / getAll()` returning a `Map<string, Adapter>`, with duplicate registration overwriting rather than throwing. That accommodates dev-time hot-reload scenarios without failing loud in production.
+
+User stories addressed:
+
+- **16** — "build a custom adapter for my header bidding framework"
+- **17** — "build a custom ad server adapter"
+- **19** — "TypeScript type definitions for the component, adapters, and registry"
+- **20** — "clear adapter interfaces documented and exported"
+- **23** — "adapters registered via a global registry"
+
+The current codebase has no registry. `demo/mock-adapter.ts` shows the informal adapter pattern — a factory returning `{ start(), stop() }` that adds document-level listeners to lifecycle events. This issue formalizes that shape into a typed contract.
+
+## Public API
+
+### Registries
+
+Exported from the package root:
+
+```ts
+export const AdServerRegistry: AdapterRegistry<AdServerAdapter>;
+export const HeaderBiddingRegistry: AdapterRegistry<HeaderBiddingAdapter>;
+```
+
+Both are module-scoped singletons. Publishers import and use them directly — no construction required:
+
+```ts
+import { HeaderBiddingRegistry } from "ad-unit-component";
+HeaderBiddingRegistry.register("prebid", PrebidAdapter);
+```
+
+### `AdapterRegistry<T>` class
+
+Exported so the ecosystem can create additional registries if a new adapter category arises (e.g. analytics adapters, refresh policy adapters):
+
+```ts
+export class AdapterRegistry<T extends { readonly name: string }> {
+  constructor(label: string);
+  register(name: string, adapter: T): void;
+  get(name: string): T | undefined;
+  getAll(): Map<string, T>;
+}
+```
+
+- `label` — identifier shown in the duplicate-registration warning (e.g. `"AdServerRegistry"`).
+- The `T extends { readonly name: string }` constraint keeps the registry consistent with the interface contract without forcing a specific adapter shape.
+
+### `register(name, adapter)`
+
+Stores `adapter` under `name`. If `name` is already registered, emits a single `console.warn` and overwrites:
+
+```
+[AdServerRegistry] adapter "gam" already registered; overwriting
+```
+
+Returns `void`. Duplicate detection uses `Map.has()`, so names are case-sensitive and must match exactly. The warn-and-overwrite behavior supports dev-time hot-reload — a module that re-executes its top-level `register(...)` call should not throw.
+
+### `get(name)`
+
+Returns the stored adapter or `undefined` for an unknown name. Pure lookup — no side effects.
+
+### `getAll()`
+
+Returns a **snapshot copy** of the internal map:
+
+```ts
+const snapshot = HeaderBiddingRegistry.getAll();
+snapshot.delete("prebid");            // does NOT mutate the registry
+HeaderBiddingRegistry.get("prebid");  // still returns the adapter
+```
+
+Returning a copy (`new Map(this.#adapters)`) prevents consumer mutations from corrupting registry state. Ordering is Map insertion order (per the ECMAScript `Map` spec).
+
+### Adapter interfaces
+
+```ts
+export interface HeaderBiddingAdapter {
+  readonly name: string;
+  init(config?: unknown): void | Promise<void>;
+  destroy(): void | Promise<void>;
+}
+
+export interface AdServerAdapter {
+  readonly name: string;
+  init(config?: unknown): void | Promise<void>;
+  destroy(): void | Promise<void>;
+}
+```
+
+Three design notes:
+
+1. **Method syntax (`init(...)`, not `init: (...) => ...`).** TypeScript checks method signatures **bivariantly** regardless of `strictFunctionTypes`. That is what lets concrete adapters declare a narrower `init(config: PrebidConfig): void` and still be structurally assignable to `HeaderBiddingAdapter`. Publishers calling `PrebidAdapter.init(prebidConfig)` get full type checking.
+2. **Two separate interfaces, not a shared alias.** Structurally identical today, but the PRD's "Ad Server Adapter Interface" section anticipates divergence — ad server adapters own render/targeting/refresh concerns that header bidding adapters don't. Keeping them distinct lets those methods land without a breaking type-rename.
+3. **`void | Promise<void>` return type.** Adapters are free to be synchronous or to `await` script loading inside `init()` / network teardown inside `destroy()`. Consumers can `await adapter.init(config)` if they care about completion.
+
+The interfaces explicitly do **not** prescribe:
+
+- Which lifecycle events to listen to (that's the adapter's concern — see `demo/mock-adapter.ts` for the `ad-unit:fetch` + `ad-unit:render` + `ad-unit:disconnected` listener pattern)
+- How `init()` discovers config (can be positional, object-form, or from a separate `configure()` method — adapter-specific)
+- How state is stored internally (module closures vs class instances vs Maps — adapter's call)
+
+Interfaces exist **only** for type safety and discoverability.
+
+## Internal implementation
+
+### `src/adapters.ts`
+
+Module contains only the two exported interface declarations (about 15 lines including JSDoc). Kept separate from `src/registry.ts` so community adapter authors have one obvious place to look when implementing a new adapter.
+
+### `src/registry.ts`
+
+Single class with two singleton instantiations:
+
+```ts
+import type { AdServerAdapter, HeaderBiddingAdapter } from "./adapters";
+
+export class AdapterRegistry<T extends { readonly name: string }> {
+  readonly #label: string;
+  readonly #adapters = new Map<string, T>();
+
+  constructor(label: string) {
+    this.#label = label;
+  }
+
+  register(name: string, adapter: T): void {
+    if (this.#adapters.has(name)) {
+      console.warn(
+        `[${this.#label}] adapter "${name}" already registered; overwriting`,
+      );
+    }
+    this.#adapters.set(name, adapter);
+  }
+
+  get(name: string): T | undefined {
+    return this.#adapters.get(name);
+  }
+
+  getAll(): Map<string, T> {
+    return new Map(this.#adapters);
+  }
+}
+
+export const AdServerRegistry = new AdapterRegistry<AdServerAdapter>(
+  "AdServerRegistry",
+);
+export const HeaderBiddingRegistry = new AdapterRegistry<HeaderBiddingAdapter>(
+  "HeaderBiddingRegistry",
+);
+```
+
+Uses native `#private` fields rather than TypeScript `private`, per AGENTS.md. The `T extends { readonly name: string }` generic constraint is not strictly required by the three methods, but encodes the registry contract at the type system: everything you put in has a `name`.
+
+### `src/index.ts`
+
+Add:
+
+```ts
+export {
+  AdapterRegistry,
+  AdServerRegistry,
+  HeaderBiddingRegistry,
+} from "./registry";
+export type { AdServerAdapter, HeaderBiddingAdapter } from "./adapters";
+```
+
+Existing exports stay unchanged.
+
+### `demo/mock-adapter.ts` refactor
+
+The current factory returns `{ start(), stop() }`. Rename to implement `HeaderBiddingAdapter`:
+
+```ts
+// Before:
+export interface MockAdapter { start(): void; stop(): void; }
+export function createMockAdapter(options?): MockAdapter { ... }
+
+// After:
+import type { HeaderBiddingAdapter } from "../src";
+export function createMockAdapter(options?: MockAdapterOptions): HeaderBiddingAdapter { ... }
+```
+
+Body change is a rename:
+
+- `start()` → `init(config?: unknown)` — body identical (attaches three document listeners, flips `started` flag). `config` arg is accepted and ignored; factory options already populated the construction-time config path.
+- `stop()` → `destroy()` — body identical (removes the three document listeners, clears pending auctions, flips `started` flag).
+- Returned object gains a `name: "mock"` field.
+- Local `MockAdapter` interface is deleted.
+
+### Demo scenario call-site updates
+
+Scenarios that instantiate the mock adapter update their wiring:
+
+```ts
+// Before:
+const adapter = createMockAdapter();
+adapter.start();
+// ... later
+adapter.stop();
+
+// After:
+import { HeaderBiddingRegistry } from "../../src";
+const adapter = createMockAdapter();
+HeaderBiddingRegistry.register(adapter.name, adapter);
+adapter.init();
+// ... later (e.g. scenario cleanup)
+adapter.destroy();
+```
+
+Files touched: any of `demo/scenarios/lifecycle.ts`, `demo/scenarios/viewport.ts`, `demo/scenarios/blocking.ts`, `demo/scenarios/refresh.ts` that call `createMockAdapter`.
+
+## Testing
+
+`src/registry.test.ts` — `bun:test`, no DOM needed (registry is plain ES code). Style mirrors `src/ad-unit.test.ts`: per-field assertions, small focused tests, shared fixtures declared at the top.
+
+Coverage:
+
+1. `register()` stores the adapter; `get(name)` returns it
+2. `get()` on unknown name returns `undefined`
+3. `getAll()` returns every registered adapter in insertion order
+4. `getAll()` returns a snapshot copy — mutating the returned map does not affect the registry
+5. Duplicate `register()` emits `console.warn` (asserted via `spyOn(console, "warn")`); message includes both the registry label and the adapter name
+6. Duplicate `register()` overwrites — `get()` returns the most recently registered adapter
+7. `AdServerRegistry` and `HeaderBiddingRegistry` singletons are independent — registering in one does not leak to the other
+
+Each functional test constructs a fresh `new AdapterRegistry<SomeAdapter>("test")` for isolation. The singleton-independence test (#7) uses the exported `AdServerRegistry` / `HeaderBiddingRegistry` and resets them explicitly in `afterEach` (since they are process-scoped).
+
+The TypeScript bivariance property (concrete adapters narrowing `init()`) is verified by the test file itself compiling — a deliberately typed `const adapter: HeaderBiddingAdapter = { name: "prebid", init(cfg: { units: Record<string, unknown> }) { ... }, destroy() {} }` sits in the test file as a compile-time check.
+
+## Out of scope
+
+- **`demo/scenarios/registry.html`** — a follow-up scenario that shows register/get/getAll and the "already registered" warning visually. Mentioned as a stub in `plans/demo-test-harness.md`; its own issue.
+- **Subpath exports** (`ad-unit-component/adapters/gam` etc.) — PRD Phase 4, tracked separately.
+- **Adapter implementations** — GAM (#10), Prebid (#11), apstag (#12) are each their own issue.
+- **`unregister(name)` method** — not in the issue or PRD. The hot-reload case is covered by overwrite-via-duplicate-register. If a real need for explicit removal emerges, it can be added without breaking the current API.
+- **Registry events** (e.g. an `onRegister` hook) — not required and not in the PRD.
+- **Ordered / typed dispatch across multiple adapters** — the registry does not coordinate event dispatch. Each adapter owns its own `document.addEventListener` wiring, so listener order is determined by the order `init()` is called, which is a publisher concern.
+
+## Further notes
+
+- The registry holds adapter references but does not call `init()` or `destroy()` itself. Activation is the publisher's responsibility, matching the PRD's usage example. This keeps the registry's role narrow — pure name → adapter lookup.
+- Because registries are module-level singletons, they are process-scoped. That is the intended design for browser bundles (one copy per page). Server-side rendering is explicitly out of scope for v1 per the PRD.
+- A future "refresh adapter" or "analytics adapter" category could reuse `AdapterRegistry<T>` directly — exporting the class costs nothing and avoids a duplicated implementation later.

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -1,0 +1,28 @@
+/**
+ * Contract for header bidding adapters (Prebid, apstag, etc.).
+ *
+ * Implementers subscribe to `<ad-unit>` lifecycle events (typically via
+ * `document.addEventListener`) and coordinate auction state. The interface
+ * does not prescribe event wiring — that is the adapter's concern. It exists
+ * so publishers have a consistent activation shape and TypeScript consumers
+ * get autocompletion.
+ */
+export interface HeaderBiddingAdapter {
+  readonly name: string;
+  init(config?: unknown): void | Promise<void>;
+  destroy(): void | Promise<void>;
+}
+
+/**
+ * Contract for ad server adapters (GAM, etc.).
+ *
+ * Structurally identical to `HeaderBiddingAdapter` today. Kept as a distinct
+ * type so the two roles can diverge without a breaking change (e.g. ad
+ * server adapters may later add a `setTargeting()` method referenced in the
+ * parent PRD).
+ */
+export interface AdServerAdapter {
+  readonly name: string;
+  init(config?: unknown): void | Promise<void>;
+  destroy(): void | Promise<void>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,12 @@ export {
   type AdUnitLifecycleDetail,
   AdUnitLifecycleEvent,
 } from "./ad-unit";
+export type { AdServerAdapter, HeaderBiddingAdapter } from "./adapters";
+export {
+  AdapterRegistry,
+  AdServerRegistry,
+  HeaderBiddingRegistry,
+} from "./registry";
 export {
   type BannerFormat,
   type BannerMediaType,

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import type { AdServerAdapter, HeaderBiddingAdapter } from "./adapters";
+import {
+  AdapterRegistry,
+  AdServerRegistry,
+  HeaderBiddingRegistry,
+} from "./registry";
+
+function makeAdapter(name: string): HeaderBiddingAdapter {
+  return {
+    name,
+    init() {},
+    destroy() {},
+  };
+}
+
+describe("AdapterRegistry", () => {
+  test("register() stores an adapter retrievable via get()", () => {
+    const registry = new AdapterRegistry<HeaderBiddingAdapter>("test");
+    const adapter = makeAdapter("prebid");
+    registry.register("prebid", adapter);
+    expect(registry.get("prebid")).toBe(adapter);
+  });
+
+  test("get() returns undefined for unknown name", () => {
+    const registry = new AdapterRegistry<HeaderBiddingAdapter>("test");
+    expect(registry.get("unknown")).toBeUndefined();
+  });
+
+  test("getAll() returns all registered adapters in insertion order", () => {
+    const registry = new AdapterRegistry<HeaderBiddingAdapter>("test");
+    const prebid = makeAdapter("prebid");
+    const apstag = makeAdapter("apstag");
+    registry.register("prebid", prebid);
+    registry.register("apstag", apstag);
+    const all = registry.getAll();
+    expect(Array.from(all.keys())).toEqual(["prebid", "apstag"]);
+    expect(all.get("prebid")).toBe(prebid);
+    expect(all.get("apstag")).toBe(apstag);
+  });
+
+  test("getAll() returns a snapshot — mutating it does not affect the registry", () => {
+    const registry = new AdapterRegistry<HeaderBiddingAdapter>("test");
+    const adapter = makeAdapter("prebid");
+    registry.register("prebid", adapter);
+    const snapshot = registry.getAll();
+    snapshot.delete("prebid");
+    snapshot.set("fake", makeAdapter("fake"));
+    expect(registry.get("prebid")).toBe(adapter);
+    expect(registry.get("fake")).toBeUndefined();
+  });
+
+  describe("duplicate registration", () => {
+    let warnSpy: ReturnType<typeof spyOn<Console, "warn">>;
+
+    beforeEach(() => {
+      warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    test("warns via console.warn with registry label and adapter name", () => {
+      const registry = new AdapterRegistry<HeaderBiddingAdapter>("MyRegistry");
+      registry.register("prebid", makeAdapter("prebid"));
+      registry.register("prebid", makeAdapter("prebid"));
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0]?.[0]);
+      expect(message).toContain("MyRegistry");
+      expect(message).toContain("prebid");
+    });
+
+    test("overwrites — get() returns the later adapter", () => {
+      const registry = new AdapterRegistry<HeaderBiddingAdapter>("test");
+      const first = makeAdapter("prebid");
+      const second = makeAdapter("prebid");
+      registry.register("prebid", first);
+      registry.register("prebid", second);
+      expect(registry.get("prebid")).toBe(second);
+    });
+  });
+});
+
+describe("module singletons", () => {
+  test("AdServerRegistry and HeaderBiddingRegistry are independent", () => {
+    const adServer: AdServerAdapter = {
+      name: "gam-independence-test",
+      init() {},
+      destroy() {},
+    };
+    const headerBidder: HeaderBiddingAdapter = {
+      name: "prebid-independence-test",
+      init() {},
+      destroy() {},
+    };
+    AdServerRegistry.register("gam-independence-test", adServer);
+    HeaderBiddingRegistry.register("prebid-independence-test", headerBidder);
+    expect(AdServerRegistry.get("gam-independence-test")).toBe(adServer);
+    expect(AdServerRegistry.get("prebid-independence-test")).toBeUndefined();
+    expect(HeaderBiddingRegistry.get("prebid-independence-test")).toBe(
+      headerBidder,
+    );
+    expect(HeaderBiddingRegistry.get("gam-independence-test")).toBeUndefined();
+  });
+
+  test("concrete adapter with narrowed init() signature is assignable (bivariance)", () => {
+    // This is primarily a compile-time check: method bivariance lets us
+    // narrow `init`'s parameter from `unknown` to `PrebidConfig` even under
+    // strict mode. If TypeScript ever tightens method variance, this file
+    // stops compiling.
+    interface PrebidConfig {
+      units: Record<string, unknown>;
+    }
+
+    const PrebidAdapter: HeaderBiddingAdapter = {
+      name: "prebid-bivariance-test",
+      init(config: PrebidConfig = { units: {} }) {
+        void config;
+      },
+      destroy() {},
+    };
+
+    HeaderBiddingRegistry.register("prebid-bivariance-test", PrebidAdapter);
+    expect(HeaderBiddingRegistry.get("prebid-bivariance-test")).toBe(
+      PrebidAdapter,
+    );
+  });
+});

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,34 @@
+import type { AdServerAdapter, HeaderBiddingAdapter } from "./adapters";
+
+export class AdapterRegistry<T extends { readonly name: string }> {
+  readonly #label: string;
+  readonly #adapters = new Map<string, T>();
+
+  constructor(label: string) {
+    this.#label = label;
+  }
+
+  register(name: string, adapter: T): void {
+    if (this.#adapters.has(name)) {
+      console.warn(
+        `[${this.#label}] adapter "${name}" already registered; overwriting`,
+      );
+    }
+    this.#adapters.set(name, adapter);
+  }
+
+  get(name: string): T | undefined {
+    return this.#adapters.get(name);
+  }
+
+  getAll(): Map<string, T> {
+    return new Map(this.#adapters);
+  }
+}
+
+export const AdServerRegistry = new AdapterRegistry<AdServerAdapter>(
+  "AdServerRegistry",
+);
+export const HeaderBiddingRegistry = new AdapterRegistry<HeaderBiddingAdapter>(
+  "HeaderBiddingRegistry",
+);


### PR DESCRIPTION
## Summary

- Adds `AdServerRegistry` and `HeaderBiddingRegistry` — module-scoped singletons backed by a shared generic `AdapterRegistry<T>` class with `register(name, adapter)` / `get(name)` / `getAll()`
- Exports two TypeScript interfaces — `AdServerAdapter` and `HeaderBiddingAdapter` — with `readonly name`, `init(config?: unknown)`, `destroy()` at minimum. Declared with method syntax so concrete adapters can narrow `init()` under TypeScript's bivariant method-signature check
- Duplicate `register()` emits `console.warn` with the registry label + adapter name and overwrites — supports hot-reload without failing loud in prod
- `getAll()` returns a fresh `Map` snapshot so consumers can't corrupt registry state by mutating the returned map
- Refactors `demo/mock-adapter.ts` to implement `HeaderBiddingAdapter` (`start/stop` → `init/destroy`, adds `name: "mock"`). The 4 demo scenarios now register the adapter with `HeaderBiddingRegistry` before calling `init()`, matching the production usage pattern from the parent PRD

## Design

Full design in [`docs/superpowers/specs/2026-04-15-adapter-registry-design.md`](docs/superpowers/specs/2026-04-15-adapter-registry-design.md). Implementation plan in [`docs/superpowers/plans/2026-04-15-adapter-registry.md`](docs/superpowers/plans/2026-04-15-adapter-registry.md).

Key decisions:

- **Single generic class, two singletons** — both registries share one implementation via `AdapterRegistry<T>`. The class is exported so future adapter categories (analytics, refresh policy) can reuse it
- **Two distinct interfaces, not a shared alias** — structurally identical today, but kept separate so the roles can diverge (the PRD's "Ad Server Adapter Interface" anticipates `setTargeting()` etc. that header bidding adapters won't need)
- **Method-syntax bivariance** lets concrete adapters declare `init(config: PrebidConfig)` and still be structurally assignable to `HeaderBiddingAdapter` — verified by a compile-time test in the test file

## Test plan

- [x] `bun test` — 162 pass, 0 fail (8 new registry tests, 8 existing mock-adapter tests updated to use `init/destroy`, all ad-unit + parse-sizes tests unchanged)
- [x] `bun run lint` — clean (`Checked 30 files in 35ms. No fixes applied.`)
- [x] `bun run build` — exit 0; `dist/index.d.ts` exposes `AdapterRegistry`, `AdServerRegistry`, `HeaderBiddingRegistry`, `AdServerAdapter`, `HeaderBiddingAdapter`
- [x] Lefthook pre-commit hooks (Biome `check` + oxlint `compat`) green on both code-bearing commits

## Out of scope (follow-ups)

- `demo/scenarios/registry.html` UI scenario that visually demonstrates register/get/getAll + the "already registered" warning
- Subpath exports for adapters (`ad-unit-component/adapters/gam` etc.) — PRD Phase 4
- Adapter implementations — GAM (#10), Prebid (#11), apstag (#12)
- `unregister(name)` — not in the issue/PRD; duplicate-register overwrite handles the hot-reload path

Closes #7