### PR TITLE
chore: address PR #29 review nits

### DIFF
--- a/demo/mock-adapter.ts
+++ b/demo/mock-adapter.ts
@@ -82,7 +82,9 @@ export function createMockAdapter(
 
   return {
     name: "mock",
-    init() {
+    // Config is accepted for interface conformance but ignored — the factory
+    // already took construction-time options.
+    init(_config?: unknown) {
       if (started) return;
       document.addEventListener("ad-unit:fetch", onFetch);
       document.addEventListener("ad-unit:render", onRender);

--- a/docs/superpowers/specs/2026-04-15-adapter-registry-design.md
+++ b/docs/superpowers/specs/2026-04-15-adapter-registry-design.md
@@ -241,9 +241,9 @@ Coverage:
 6. Duplicate `register()` overwrites — `get()` returns the most recently registered adapter
 7. `AdServerRegistry` and `HeaderBiddingRegistry` singletons are independent — registering in one does not leak to the other
 
-Each functional test constructs a fresh `new AdapterRegistry<SomeAdapter>("test")` for isolation. The singleton-independence test (#7) uses the exported `AdServerRegistry` / `HeaderBiddingRegistry` and resets them explicitly in `afterEach` (since they are process-scoped).
+Each functional test constructs a fresh `new AdapterRegistry<SomeAdapter>("test")` for isolation. The singleton-independence test (#7) is the **only** test that touches the exported `AdServerRegistry` / `HeaderBiddingRegistry`; because the registries have no public `unregister()`, it cannot reset them in `afterEach`. It mitigates test-order fragility by using unique suffixed names (`-independence-test`) that cannot collide with any other test in the file. The bivariance test uses its own fresh registry rather than a singleton, so adding a new singleton-touching test does not force a refactor.
 
-The TypeScript bivariance property (concrete adapters narrowing `init()`) is verified by the test file itself compiling — a deliberately typed `const adapter: HeaderBiddingAdapter = { name: "prebid", init(cfg: { units: Record<string, unknown> }) { ... }, destroy() {} }` sits in the test file as a compile-time check.
+The TypeScript bivariance property (concrete adapters narrowing `init()`) is verified by the test file itself compiling — a deliberately typed `const adapter: HeaderBiddingAdapter = { name: "prebid", init(config: { units: Record<string, unknown> }) { ... }, destroy() {} }` sits in the test file as a compile-time check. The narrowed parameter is **required** (no default value), so the check covers the required-argument case, not just the optional one.
 
 ## Out of scope
 

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -82,6 +82,12 @@ describe("AdapterRegistry", () => {
   });
 });
 
+// The module singletons are process-scoped and cannot be reset — there is no
+// public `unregister()`. This block is the only place that touches them, and
+// it uses unique per-test names (suffixed `-independence-test`) so the state
+// it leaves behind can never collide with anything else in this file. Any
+// future singleton test must follow the same rule or be rewritten to use a
+// fresh `new AdapterRegistry(...)` instance instead.
 describe("module singletons", () => {
   test("AdServerRegistry and HeaderBiddingRegistry are independent", () => {
     const adServer: AdServerAdapter = {
@@ -103,27 +109,29 @@ describe("module singletons", () => {
     );
     expect(HeaderBiddingRegistry.get("gam-independence-test")).toBeUndefined();
   });
+});
 
-  test("concrete adapter with narrowed init() signature is assignable (bivariance)", () => {
-    // This is primarily a compile-time check: method bivariance lets us
-    // narrow `init`'s parameter from `unknown` to `PrebidConfig` even under
-    // strict mode. If TypeScript ever tightens method variance, this file
-    // stops compiling.
+describe("TypeScript bivariance", () => {
+  // Compile-time check: method bivariance lets a concrete adapter declare a
+  // narrower `init(config: PrebidConfig)` and still be assignable to
+  // `HeaderBiddingAdapter`. If TypeScript ever tightens method variance, this
+  // file stops compiling. No default value on `config` so the guarantee
+  // covers the required-argument case, not just the optional one.
+  test("concrete adapter with narrowed required init() param is assignable", () => {
     interface PrebidConfig {
       units: Record<string, unknown>;
     }
 
     const PrebidAdapter: HeaderBiddingAdapter = {
-      name: "prebid-bivariance-test",
-      init(config: PrebidConfig = { units: {} }) {
+      name: "prebid",
+      init(config: PrebidConfig) {
         void config;
       },
       destroy() {},
     };
 
-    HeaderBiddingRegistry.register("prebid-bivariance-test", PrebidAdapter);
-    expect(HeaderBiddingRegistry.get("prebid-bivariance-test")).toBe(
-      PrebidAdapter,
-    );
+    const registry = new AdapterRegistry<HeaderBiddingAdapter>("bivariance");
+    registry.register(PrebidAdapter.name, PrebidAdapter);
+    expect(registry.get("prebid")).toBe(PrebidAdapter);
   });
 });

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -8,6 +8,17 @@ export class AdapterRegistry<T extends { readonly name: string }> {
     this.#label = label;
   }
 
+  /**
+   * Registers `adapter` under `name`. Duplicate names emit a single
+   * `console.warn` and overwrite the previous entry — this supports dev-time
+   * hot-reload without failing loud in production.
+   *
+   * The warn message is stable so adapter authors can grep for it:
+   *
+   * ```text
+   * [AdServerRegistry] adapter "gam" already registered; overwriting
+   * ```
+   */
   register(name: string, adapter: T): void {
     if (this.#adapters.has(name)) {
       console.warn(


### PR DESCRIPTION
## Summary

Four non-blocking follow-ups from the code review of #29 (adapter registries + TypeScript interfaces). All are internal polish — no public API shape change.

- **Bivariance test off the singleton** — [`src/registry.test.ts`](src/registry.test.ts). The compile-time bivariance check now uses a fresh `new AdapterRegistry<HeaderBiddingAdapter>("bivariance")`. The singleton-independence test is now the only test that touches `AdServerRegistry` / `HeaderBiddingRegistry`, and it uses suffixed names that cannot collide. Adding future singleton tests no longer requires a refactor.
- **Required bivariance parameter** — [`src/registry.test.ts`](src/registry.test.ts). Dropped the default value on the test adapter's `init(config: PrebidConfig)`, so the compile-time guarantee covers the required-argument case, not just the optional one.
- **`register()` warn-format JSDoc** — [`src/registry.ts`](src/registry.ts). The exact `console.warn` message is now documented on `AdapterRegistry.register()` so adapter authors can grep for it. JSDoc carries through to the published [`dist/registry.d.ts`](dist/registry.d.ts).
- **Explicit `_config?: unknown` on mock-adapter `init()`** — [`demo/mock-adapter.ts`](demo/mock-adapter.ts). Surfaces interface-conformance intent; behavior unchanged (body still ignores the arg).

Spec updated to match the actual testing approach (no `afterEach` reset — there's no public `unregister()`, unique names handle isolation instead).

## Test plan

- [x] `bun test` — 162 pass, 0 fail
- [x] `bun run lint` — clean
- [x] `bun run build` — exit 0; `dist/registry.d.ts` shows the new JSDoc on `register()`
- [x] Lefthook pre-commit hooks (`check` + `compat`) green